### PR TITLE
CDPE-2201 adds pin_nodes_to_env function

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -6,7 +6,7 @@
 **Functions**
 
 * [`cd4pe_deployments::get_node_group`](#cd4pe_deploymentsget_node_group): Get information about a Puppet Enterprise node group
-* [`cd4pe_deployments::pin_nodes_to_env`](#cd4pe_deploymentspin_nodes_to_env): Get information about a Puppet Enterprise node group
+* [`cd4pe_deployments::pin_nodes_to_env`](#cd4pe_deploymentspin_nodes_to_env): Pin a list of nodes to an environment group
 
 ## Functions
 
@@ -58,14 +58,13 @@ The ID string of the node group
 
 Type: Ruby 4.x API
 
-Get information about a Puppet Enterprise node group
+Pin a list of nodes to an environment group
 
 #### `cd4pe_deployments::pin_nodes_to_env(Array $nodes, String $node_group_id)`
 
 The cd4pe_deployments::pin_nodes_to_env function.
 
-Returns: `Object` JsonSuccess
-{ success }
+Returns: `Object` * success [Boolean] whether or not the operation was sucessful
 
 ##### `nodes`
 

--- a/lib/puppet/functions/cd4pe_deployments/pin_nodes_to_env.rb
+++ b/lib/puppet/functions/cd4pe_deployments/pin_nodes_to_env.rb
@@ -1,0 +1,30 @@
+require 'puppet_x/puppetlabs/cd4pe_client'
+
+# @summary Pin a list of nodes to an environment group
+Puppet::Functions.create_function(:'cd4pe_deployments::pin_nodes_to_env') do
+  # @param nodes
+  #   List of nodes to pin to the group
+  # @param node_group_id
+  #   The ID string of the node group
+  # @return [Object]
+  #   * success [Boolean] whether or not the operation was sucessful
+  #
+  dispatch :pin_nodes_to_env do
+    required_param 'Array', :nodes
+    required_param 'String', :node_group_id
+  end
+
+  def pin_nodes_to_env(nodes, node_group_id)
+    client = PuppetX::Puppetlabs::CD4PEClient.new
+
+    response = client.pin_nodes_to_env(nodes, node_group_id)
+    if response.code == '200' # rubocop:disable Style/GuardClause
+      response_body = JSON.parse(response.body, symbolize_names: true)
+      return response_body unless response_body.empty?
+    else
+      raise Puppet::Error, "Server returned HTTP #{response.code}"
+    end
+  rescue => exception
+    raise Puppet::Error, "Problem pinning nodes to group=#{node_group_id}, response code #{response.code}", exception.backtrace
+  end
+end

--- a/spec/functions/cd4pe/pin_nodes_to_env_spec.rb
+++ b/spec/functions/cd4pe/pin_nodes_to_env_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+require_relative '../../../lib/puppet/functions/cd4pe_deployments/get_node_group'
+require 'webmock/rspec'
+
+describe 'cd4pe_deployments::pin_nodes_to_env' do
+  it 'exists' do
+    is_expected.not_to eq(nil)
+  end
+
+  it 'requires 2 parameters' do
+    is_expected.to run.with_params.and_raise_error(ArgumentError)
+  end
+
+  context 'happy' do
+    include_context 'deployment'
+
+    let(:nodes) { ['carlscoolnode.one.net', 'carlscoolnode.two.net', 'carlscoolnode.three.net'] }
+    let(:response) { { success: true } }
+
+    it 'succeeds with parameters' do
+      stub_request(:post, ajax_url)
+        .with(
+          headers: { 'content-type' => 'application/json', 'authorization' => "Bearer token #{ENV['DEPLOYMENT_TOKEN']}" },
+          body: {
+            op: 'PinNodesToGroup',
+            content: { deploymentId: deployment_id, nodeGroupId: node_group_id, nodes: nodes },
+          },
+        )
+        .to_return(body: JSON.generate(response), status: 200)
+        .times(1)
+
+      is_expected.to run.with_params(nodes, node_group_id).and_return(response)
+    end
+
+    it 'fails with non-200 response code' do
+      stub_request(:post, ajax_url)
+        .with(
+          headers: { 'content-type' => 'application/json', 'authorization' => "Bearer token #{ENV['DEPLOYMENT_TOKEN']}" },
+          body: {
+            op: 'PinNodesToGroup',
+            content: { deploymentId: deployment_id, nodeGroupId: node_group_id, nodes: nodes },
+          },
+        )
+        .to_return(body: JSON.generate(response), status: 404)
+        .times(1)
+
+      is_expected.to run.with_params(nodes, node_group_id).and_raise_error(Puppet::Error)
+    end
+  end
+end


### PR DESCRIPTION
### currently
We don't have a function to perform this task. 

### but now
We do. This function takes a list of nodes and a node group ID and hits the relatively new PipelinesInfra ajax endpoint `PinNodesToGroup` to contact PE and pin nodes to a specific environment group.

### because
It's needed to create cool deployment policies

### testing
Some unit tests to make sure table steaks are cooked thoroughly.