### PR TITLE
(CDPE-2255) Add a function to create a temp node group

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -5,6 +5,7 @@
 
 **Functions**
 
+* [`cd4pe_deployments::create_temp_node_group`](#cd4pe_deploymentscreate_temp_node_group): Create a temporary Puppet Enterprise node group
 * [`cd4pe_deployments::delete_node_group`](#cd4pe_deploymentsdelete_node_group): Delete a Puppet Enterprise node group
 * [`cd4pe_deployments::deploy_code`](#cd4pe_deploymentsdeploy_code): Performs a Puppet Enterprise Code Manager deployment for the given environment
 * [`cd4pe_deployments::get_node_group`](#cd4pe_deploymentsget_node_group): Get information about a Puppet Enterprise node group
@@ -13,6 +14,59 @@
 * [`cd4pe_deployments::wait_for_approval`](#cd4pe_deploymentswait_for_approval): Blocks further plan execution until the deployment is approved in CD4PE
 
 ## Functions
+
+### cd4pe_deployments::create_temp_node_group
+
+Type: Ruby 4.x API
+
+Create a temporary Puppet Enterprise node group
+
+#### Examples
+
+##### Create temp node group with parent node group id '3ed5c6c0-be33-4c62-9f41-a863a282b6ae'
+
+```puppet
+$parent_node_group_id = "3ed5c6c0-be33-4c62-9f41-a863a282b6ae"
+$test_environment = "development"
+create_temp_node_group($parent_node_group_id, $test_environment, true)
+```
+
+#### `cd4pe_deployments::create_temp_node_group(String $parent_node_group_id, String $environment_name, Optional[Boolean] $is_environment_node_group)`
+
+The cd4pe_deployments::create_temp_node_group function.
+
+Returns: `Hash` contains the results of the function
+* result [Hash] Contains the new node group described by the following documentation:
+  https://puppet.com/docs/pe/2019.1/groups_endpoint.html#response-format-01
+* error [Hash] Contains error info if any was encountered during the function call
+
+##### Examples
+
+###### Create temp node group with parent node group id '3ed5c6c0-be33-4c62-9f41-a863a282b6ae'
+
+```puppet
+$parent_node_group_id = "3ed5c6c0-be33-4c62-9f41-a863a282b6ae"
+$test_environment = "development"
+create_temp_node_group($parent_node_group_id, $test_environment, true)
+```
+
+##### `parent_node_group_id`
+
+Data type: `String`
+
+The ID string of the parent node group
+
+##### `environment_name`
+
+Data type: `String`
+
+The name of the environment to be associated with the temp node group
+
+##### `is_environment_node_group`
+
+Data type: `Optional[Boolean]`
+
+A Boolean to indicate if the node group should be an environment node group. Defaults to 'true'.
 
 ### cd4pe_deployments::delete_node_group
 
@@ -70,7 +124,7 @@ The cd4pe_deployments::deploy_code function.
 
 Returns: `Hash` contains the results of the function
 * result [Array[Hash]] a list of deployment status objects described by the following documentation:
-  https://puppet.com/docs/pe/2018.1/code_manager_api.html#response-format
+  https://puppet.com/docs/pe/latest/code_manager_api.html#response-format
 * error [Hash] Contains error info if any was encountered during the function call
 
 ##### Examples
@@ -203,7 +257,7 @@ The cd4pe_deployments::run_puppet function.
 
 Returns: `Hash` contains the results of the function
 * result [Hash] This contains data described by the following documentation:
-  https://puppet.com/docs/pe/2018.1/orchestrator_api_jobs_endpoint.html#get-jobs-job-id
+  https://puppet.com/docs/pe/latest/orchestrator_api_jobs_endpoint.html#get-jobs-job-id
 * error [Hash] Contains error info if any was encountered during the function call
 
 ##### Examples
@@ -232,13 +286,13 @@ The list of nodes to Run puppet on
 
 Data type: `Optional[Boolean]`
 
-A Boolean to run Puppet in Noop mode
+A Boolean to run Puppet in Noop mode. Defaults to 'false'.
 
 ##### `concurrency`
 
 Data type: `Optional[Integer]`
 
-The number of nodes to concurrently run Puppet on
+The number of nodes to concurrently run Puppet on. Defaults to the Puppet Orchestrator default.
 
 ### cd4pe_deployments::wait_for_approval
 

--- a/lib/puppet/functions/cd4pe_deployments/create_temp_node_group.rb
+++ b/lib/puppet/functions/cd4pe_deployments/create_temp_node_group.rb
@@ -1,0 +1,42 @@
+require 'puppet_x/puppetlabs/cd4pe_client'
+require 'puppet_x/puppetlabs/cd4pe_function_result'
+
+# @summary Create a temporary Puppet Enterprise node group
+Puppet::Functions.create_function(:'cd4pe_deployments::create_temp_node_group') do
+  # @param [String] parent_node_group_id
+  #   The ID string of the parent node group
+  # @param [String] environment_name
+  #   The name of the environment to be associated with the temp node group
+  # @param [Optional[Boolean]] is_environment_node_group
+  #   A Boolean to indicate if the node group should be an environment node group. Defaults to 'true'.
+  # @example Create temp node group with parent node group id '3ed5c6c0-be33-4c62-9f41-a863a282b6ae'
+  #   $parent_node_group_id = "3ed5c6c0-be33-4c62-9f41-a863a282b6ae"
+  #   $test_environment = "development"
+  #   create_temp_node_group($parent_node_group_id, $test_environment, true)
+  # @return [Hash] contains the results of the function
+  #   * result [Hash] Contains the new node group described by the following documentation:
+  #     https://puppet.com/docs/pe/2019.1/groups_endpoint.html#response-format-01
+  #   * error [Hash] Contains error info if any was encountered during the function call
+  dispatch :create_temp_node_group do
+    required_param 'String', :parent_node_group_id
+    required_param 'String', :environment_name
+    optional_param 'Boolean', :is_environment_node_group
+  end
+
+  def create_temp_node_group(parent_node_group_id, environment_name, is_environment_node_group = true)
+    client = PuppetX::Puppetlabs::CD4PEClient.new
+
+    response = client.create_temp_node_group(parent_node_group_id, environment_name, is_environment_node_group)
+    if response.code == '200'
+      response_body = JSON.parse(response.body, symbolize_names: true)
+      return PuppetX::Puppetlabs::CD4PEFunctionResult.create_result(response_body)
+    elsif response.code =~ %r{4[0-9]+}
+      response_body = JSON.parse(response.body, symbolize_names: true)
+      return PuppetX::Puppetlabs::CD4PEFunctionResult.create_error_result(response_body)
+    else
+      raise Puppet::Error "Unknown HTTP Error with code: #{response.code} and body #{response.body}"
+    end
+  rescue => exception
+    PuppetX::Puppetlabs::CD4PEFunctionResult.create_exception_result(exception)
+  end
+end

--- a/lib/puppet/functions/cd4pe_deployments/run_puppet.rb
+++ b/lib/puppet/functions/cd4pe_deployments/run_puppet.rb
@@ -3,14 +3,14 @@ require 'puppet_x/puppetlabs/cd4pe_function_result'
 
 # @summary Run Puppet using the Puppet Orchestrator for a set of nodes in a given environment
 Puppet::Functions.create_function(:'cd4pe_deployments::run_puppet') do
-  # @param environment_name
+  # @param [String] environment_name
   #   The name of the Puppet environment to deploy
-  # @param nodes
+  # @param [Array[String]] nodes
   #   The list of nodes to Run puppet on
-  # @param noop
-  #   A Boolean to run Puppet in Noop mode
-  # @param concurrency
-  #   The number of nodes to concurrently run Puppet on
+  # @param [Optional[Boolean]] noop
+  #   A Boolean to run Puppet in Noop mode. Defaults to 'false'.
+  # @param [Integer] concurrency
+  #   The number of nodes to concurrently run Puppet on. Defaults to the Puppet Orchestrator default.
   # @example Run Puppet on nodes in the 'development' environment
   #   $my_cool_environment = "development"
   #   $nodes = ["test1.example.com", "test2.example.com", "test3.example.com"]

--- a/lib/puppet_x/puppetlabs/cd4pe_client.rb
+++ b/lib/puppet_x/puppetlabs/cd4pe_client.rb
@@ -96,6 +96,19 @@ module PuppetX::Puppetlabs
       make_request(:post, @owner_ajax_path, get_job_status_payload.to_json)
     end
 
+    def create_temp_node_group(parent_node_group_id, environment_name, is_environment_node_group)
+      payload = {
+        op: 'CreateTempNodeGroup',
+        content: {
+          deploymentId: @config[:deployment_id],
+          parentNodeGroupId: parent_node_group_id,
+          environmentName: environment_name,
+          isEnvironmentNodeGroup: is_environment_node_group,
+        },
+      }
+      make_request(:post, @owner_ajax_path, payload.to_json)
+    end
+
     private
 
     def deployment_token

--- a/spec/functions/cd4pe/create_temp_node_group_spec.rb
+++ b/spec/functions/cd4pe/create_temp_node_group_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+require_relative '../../../lib/puppet/functions/cd4pe_deployments/create_temp_node_group'
+require 'webmock/rspec'
+
+describe 'cd4pe_deployments::create_temp_node_group' do
+  it 'exists' do
+    is_expected.not_to eq(nil)
+  end
+
+  it 'requires 2 parameters' do
+    is_expected.to run.with_params.and_raise_error(ArgumentError)
+  end
+
+  context 'happy' do
+    include_context 'deployment'
+
+    let(:environment_name) { 'development' }
+    let(:parent_node_group_id) { '3ed5c6c0-be33-4c62-9f41-a863a282b6ae' }
+
+    it 'succeeds with parameters' do
+      stub_request(:post, ajax_url)
+        .with(
+          headers: { 'content-type' => 'application/json', 'authorization' => "Bearer token #{ENV['DEPLOYMENT_TOKEN']}" },
+          body: {
+            op: 'CreateTempNodeGroup',
+            content: {
+              deploymentId: deployment_id,
+              environmentName: environment_name,
+              parentNodeGroupId: parent_node_group_id,
+              isEnvironmentNodeGroup: true,
+            },
+          },
+        )
+        .to_return(status: 200)
+        .times(1)
+      is_expected.to run.with_params(parent_node_group_id, environment_name)
+    end
+  end
+end


### PR DESCRIPTION
- Adds a new function to create a temp node group.
- Updates the docs for the `run_puppet` function so the params have
their correct types documented.
- Depends on https://github.com/puppetlabs/PipelinesInfra/pull/889