### PR TITLE
(CDPE-2488)(CDPE-2489) Add eventual consistency and feature branch plans

### DIFF
--- a/plans/eventual_consistency.pp
+++ b/plans/eventual_consistency.pp
@@ -1,4 +1,13 @@
 plan cd4pe_deployments::eventual_consistency (
 ) {
-  #stuff
+  $source_commit = system::env('CD4PE_SOURCE_COMMIT')
+  $target_node_group = get_node_group(system::env('NODE_GROUP_ID'))
+  $update_git_ref_result = update_git_branch_ref('CONTROL_REPO', $target_node_group['environment'], $source_commit)
+  if $update_git_ref_result['error'] != undef {
+    fail_plan($deploy_code_result['error']['message'], $deploy_code_result['error']['code'])
+  }
+  $deploy_code_result = deploy_code($target_node_group['environment'])
+  if $deploy_code_result['error'] != undef {
+    fail_plan($deploy_code_result['error']['message'], $deploy_code_result['error']['code'])
+  }
 }

--- a/plans/feature_branch.pp
+++ b/plans/feature_branch.pp
@@ -1,4 +1,7 @@
 plan cd4pe_deployments::feature_branch (
 ) {
-  #stuff
+  $deploy_code_result = deploy_code(system::env('CD4PE_SOURCE_BRANCH'))
+  if $deploy_code_result['error'] != undef {
+    fail_plan($deploy_code_result['error']['message'], $deploy_code_result['error']['code'])
+  }
 }


### PR DESCRIPTION
- Adds initial eventual consistency and feature branch plans.
- The logic only works for control repo Deployments.
- Hasn't been tested.