### PR TITLE
Make run_puppet() environment parameter optional

### DIFF
--- a/lib/puppet/functions/cd4pe_deployments/run_puppet.rb
+++ b/lib/puppet/functions/cd4pe_deployments/run_puppet.rb
@@ -22,8 +22,8 @@ Puppet::Functions.create_function(:'cd4pe_deployments::run_puppet') do
   #   * error [Hash] Contains error info if any was encountered during the function call
 
   dispatch :run_puppet do
-    required_param 'String', :environment_name
     required_param 'Array[String]', :nodes
+    optional_param 'String', :environment_name
     optional_param 'Boolean', :noop
     optional_param 'Integer', :concurrency
   end


### PR DESCRIPTION
Previous to this commit, the run_puppet() function's environnment
parameter was required. However, puppet agents already have a default
environmnent assigned to them either through the puppet.conf file or an
environment node group. This option should only be required when the
user wants to override the agent's assigned environment (and the agent
is permitted to do so)