### PR TITLE
Implement rolling deployment policy

### DIFF
--- a/plans/rolling.pp
+++ b/plans/rolling.pp
@@ -17,7 +17,7 @@ plan cd4pe_deployments::rolling (
 
   $sha = system::env('COMMIT')
   $target_node_group_id = system::env('NODE_GROUP_ID')
-  $target_branch = system::env('BRANCH')
+  $target_branch = system::env('REPO_TARGET_BRANCH')
 
   # Get information about the target node group
   $node_group_hash = cd4pe_deployments::get_node_group($target_node_group_id)


### PR DESCRIPTION
This commit introduces the rolling deployment policy. The policy
performs the following actions:
* Retrieves metadata on target node group
* Fails if no nodes are found in target and $fail_if_no_nodes is true
* Wait for approval if target environment is protected
* Create a temporary branch used for the temporary Puppet environment
* Deploys the temporary Puppet environment w/ Code Manager
* Create a temporary node environment group and assign it to the tmp env
* Deploy the target environment w/ a default override of the target
  Puppet env
* Group the target nodes list into batches based on $batch_size
* For each batch of nodes, run puppet in parallel
* Determine how many nodes failed and fail if $max_node_failures number is
  passed
* Update the target Puppet environment with the deployment commit
* Delete the temporary node group
* Delete the temporary git branch

Tested Scenarios:
* No nodes in target environment
* Target environment is protected
* Target environment is not protected
* $noop is true
* $batch_size is 1, $max_node_failures is 3, and 3 target nodes
  had failed runs

Todo:

- [x] Support prefixed environments
- [x] Verify temporary node groups get deleted if plan fails early