### PR TITLE
Rename wait_seconds parameter in rolling policy

### DIFF
--- a/plans/rolling.pp
+++ b/plans/rolling.pp
@@ -11,7 +11,7 @@ plan cd4pe_deployments::rolling (
   Optional[Integer] $max_node_failure,
   Integer $batch_size = 10,
   Boolean $noop = false,
-  Integer $wait_seconds = 60,
+  Integer $batch_delay = 60,
   Boolean $fail_if_no_nodes = true,
 ) {
 


### PR DESCRIPTION
Previous to this commit, the cd4pe_deployments::rolling policy had a
parameter called `wait_seconds` that defined the time in seconds that a
deployment will wait before continuing to the next batch of nodes.

This commit renames that parameter to `batch_delay` to make it clearer
to the user what the parameter does