### PR TITLE
(CDPE-2607) Fix direct/rolling policies to call run_puppet correctly

### DIFF
--- a/lib/puppet/functions/cd4pe_deployments/run_puppet.rb
+++ b/lib/puppet/functions/cd4pe_deployments/run_puppet.rb
@@ -14,7 +14,7 @@ Puppet::Functions.create_function(:'cd4pe_deployments::run_puppet') do
   # @example Run Puppet on nodes in the 'development' environment
   #   $my_cool_environment = "development"
   #   $nodes = ["test1.example.com", "test2.example.com", "test3.example.com"]
-  #   run_puppet($my_cool_environment, $nodes, false, 2)
+  #   run_puppet($nodes, false, $my_cool_environment, 2)
   # @return [Hash] contains the results of the function
   #   See [README.md]() for information on the CD4PEFunctionResult hash format
   #   * result [Hash] This contains data described by the following documentation:
@@ -23,12 +23,12 @@ Puppet::Functions.create_function(:'cd4pe_deployments::run_puppet') do
 
   dispatch :run_puppet do
     required_param 'Array[String]', :nodes
-    optional_param 'String', :environment_name
     optional_param 'Boolean', :noop
+    optional_param 'String', :environment_name
     optional_param 'Integer', :concurrency
   end
 
-  def run_puppet(environment_name, nodes, concurrency = nil, noop = false)
+  def run_puppet(nodes, noop = false, environment_name = nil, concurrency = nil)
     @client = PuppetX::Puppetlabs::CD4PEClient.new
     response = @client.run_puppet(environment_name, nodes, concurrency, noop)
     if response.code == '200'

--- a/plans/direct.pp
+++ b/plans/direct.pp
@@ -41,7 +41,7 @@ plan cd4pe_deployments::direct (
     fail_plan("No nodes found in target node group ${get_node_group_result['result']['name']}")
   }
   # Perform a Puppet run on all nodes in the environment
-  $puppet_run_result = cd4pe_deployments::run_puppet($target_environment, $nodes, $noop)
+  $puppet_run_result = cd4pe_deployments::run_puppet($nodes, $noop)
   if $puppet_run_result['error'] =~ NotUndef {
     fail_plan($puppet_run_result['error']['message'], $puppet_run_result['error']['code'])
   }

--- a/plans/rolling.pp
+++ b/plans/rolling.pp
@@ -1,6 +1,6 @@
-# @summary This deployment policy will deploy the target control repository commit to 
+# @summary This deployment policy will deploy the target control repository commit to
 #          target nodes in batches. It will craete a temporary Puppet environment and
-#          temporary node group to pull nodes out of the target environment and into 
+#          temporary node group to pull nodes out of the target environment and into
 #          the temporary environment while the deployment is taking place.
 #          When the change has been deployed to all of the target nodes, the target
 #          Puppet environment is updated with the change and all the nodes are moved
@@ -77,7 +77,7 @@ plan cd4pe_deployments::rolling (
     fail_plan("Code deployment failed to target environment ${target_environment}: ${validate_code_deploy_result[error][message]}")
   }
 
-  # Create a temporary environment node group to pin nodes to in order to run the puppet agent on 
+  # Create a temporary environment node group to pin nodes to in order to run the puppet agent on
   # nodes in the target environment in batches
   $child_group = cd4pe_deployments::create_temp_node_group($target_node_group_id, $branch, true)
   if $child_group[error] {
@@ -92,7 +92,7 @@ plan cd4pe_deployments::rolling (
 
   $batches[result].reduce(0) |$failed_count, $batch| {
     cd4pe_deployments::pin_nodes_to_env($batch, $child_group[result][id])
-    $puppet_run_result = cd4pe_deployments::run_puppet($branch, $batch, $noop)
+    $puppet_run_result = cd4pe_deployments::run_puppet($batch, $noop)
     if $puppet_run_result[error] {
       fail_plan("Could not orchestrate puppet agent runs: ${puppet_run_result[error]}")
     }

--- a/spec/functions/cd4pe/run_puppet_spec.rb
+++ b/spec/functions/cd4pe/run_puppet_spec.rb
@@ -61,7 +61,7 @@ describe 'cd4pe_deployments::run_puppet' do
         .to_return({ body: JSON.generate(state: 'running'), status: 200 }, body: JSON.generate(state: 'finished'), status: 200)
         .times(2)
 
-      is_expected.to run.with_params(environment_name, puppet_run_request[:nodes], puppet_run_request[:withNoop]).and_return('result' => { 'state' => 'finished' }, 'error' => nil)
+      is_expected.to run.with_params(puppet_run_request[:nodes], puppet_run_request[:withNoop], environment_name).and_return('result' => { 'state' => 'finished' }, 'error' => nil)
     end
   end
 end


### PR DESCRIPTION
- Makes a small change to the run_puppet function signature and
retroactive updates to the function docs
- Updates the spec tests for the run_puppet function so they pass
- Removes the environment param from calls to run_puppet in the
direct/rolling deployment policies. I have done this because the nodes
will run on their assigned environments which matches the the behavior
of pre 3.0 policies.
- Tested with the direct and rolling deployment policies manually.