### PR TITLE
CDPE-2650 create module branch if missing on eventual consistency

### DIFF
--- a/plans/eventual_consistency.pp
+++ b/plans/eventual_consistency.pp
@@ -23,6 +23,9 @@ plan cd4pe_deployments::eventual_consistency (
     $source_commit
   )
   if $update_git_ref_result['error'] =~ NotUndef {
+    # If this is a module deployment, the update ref may have failed because we get $repo_target_branch from the node
+    # group name and it may not exist on the module repository. In this case, we instead want to create a git branch
+    # from the $source_commit on the module repository.
     if($repo_type == 'MODULE'){
       $git_branch_cleanup = false
       $create_git_branch_result = cd4pe_deployments::create_git_branch(


### PR DESCRIPTION
Currently, we try to update the git ref of the entity in question on an eventual consistency deployment, no questions asked. However, in the case of a module, the branch may not exist as it comes from a node group name not an actual branch. To get back to parity with PE Module Deployments, this change adds a check to see if the update ref fails and the repo type is a module. If so, try to create a branch from the src sha instead.