### PR TITLE
Don't fail if module branch doesn't exist

### DIFF
--- a/plans/eventual_consistency.pp
+++ b/plans/eventual_consistency.pp
@@ -16,6 +16,23 @@ plan cd4pe_deployments::eventual_consistency (
   # Wait for approval if the environment is protected
   cd4pe_deployments::wait_for_approval($target_environment) |String $url| { }
 
+  # If this is a module deployment, the update ref may have fail because we get $repo_target_branch from the node
+  # group name and it may not exist on the module repository. It's best to ensure the branch exists by calling
+  # create_git_branch(). This is a safe operation beceause the function is idempotent
+  if($repo_type == 'MODULE'){
+    $git_branch_cleanup = false
+    $create_git_branch_result = cd4pe_deployments::create_git_branch(
+      $repo_type,
+      $repo_target_branch,
+      $source_commit,
+      $git_branch_cleanup
+    )
+
+    if $create_git_branch_result['error'] =~ NotUndef {
+      fail_plan($create_git_branch_result['error']['message'], $create_git_branch_result['error']['code'])
+    }
+  }
+
   # Update the branch of the target environment to the source commit
   $update_git_ref_result = cd4pe_deployments::update_git_branch_ref(
     $repo_type,
@@ -23,24 +40,9 @@ plan cd4pe_deployments::eventual_consistency (
     $source_commit
   )
   if $update_git_ref_result['error'] =~ NotUndef {
-    # If this is a module deployment, the update ref may have failed because we get $repo_target_branch from the node
-    # group name and it may not exist on the module repository. In this case, we instead want to create a git branch
-    # from the $source_commit on the module repository.
-    if($repo_type == 'MODULE'){
-      $git_branch_cleanup = false
-      $create_git_branch_result = cd4pe_deployments::create_git_branch(
-        $repo_type,
-        $repo_target_branch,
-        $source_commit,
-        $git_branch_cleanup
-      )
-
-      if $create_git_branch_result['error'] =~ NotUndef {
-        fail_plan($create_git_branch_result['error']['message'], $create_git_branch_result['error']['code'])
-      }
-    }
     fail_plan($update_git_ref_result['error']['message'], $update_git_ref_result['error']['code'])
   }
+
   # Perform the code deploy to the target environment
   $deploy_code_result = cd4pe_deployments::deploy_code($target_environment)
   $validate_code_deploy_result = cd4pe_deployments::validate_code_deploy_status($deploy_code_result)


### PR DESCRIPTION
Previous to this commit, when an eventual consistency deployment
policy was run in a module pipeline and the target branch didn't exist
on the module's vcs repository, the deployment would successfully create
the target branch on the module's repository, but fail the deployment. A
follow up deployment would succeed.

This commit ensures the branch exists before performing an update_ref by
calling cd4pe_deployments::create_git_branch() first. This is a safe
operation because create_git_branch() is idempotent. i.e. it will
succeed if the branch already exists.