### PR TITLE
CDPE-2706 adds prefix logic to the feat branch policy for control repos

### DIFF
--- a/plans/feature_branch.pp
+++ b/plans/feature_branch.pp
@@ -5,40 +5,30 @@
 plan cd4pe_deployments::feature_branch (
 ) {
   $repo_type = system::env('REPO_TYPE')
-  case $repo_type {
-    'CONTROL_REPO': {
-      # Perform a code deploy to the environment that matches the source branch.
-      $deploy_code_result = cd4pe_deployments::deploy_code(system::env('BRANCH'))
-      $validate_code_deploy_result = cd4pe_deployments::validate_code_deploy_status($deploy_code_result)
-      if ($validate_code_deploy_result['error'] != undef) {
-        fail_plan($validate_code_deploy_result['error']['message'], $validate_code_deploy_result['error']['code'] )
-      }
-    }
-    'MODULE': {
-      $feature_branch_name = system::env('BRANCH')
-      $base_branch_sha = system::env('CONTROL_REPO_BASE_FEATURE_BRANCH')
-      # Create a feature branch on the control repo based on the branch that was selected when the Deployment was added
-      # to the pipeline. Make the branch long lived.
-      $create_branch_result = cd4pe_deployments::create_git_branch('CONTROL_REPO', $feature_branch_name, $base_branch_sha, false)
-      if $create_branch_result['error'] != undef {
-        fail_plan($create_branch_result['error']['message'], $create_branch_result['error']['code'])
-      }
-      $environment_prefix = system::env('ENVIRONMENT_PREFIX')
-      # If an environment prefix was selected on the Deployment then calculate the target environment name with this prefix
-      $target_environment = $environment_prefix ? {
-        '' => $feature_branch_name,
-        String[1] => "${environment_prefix}${feature_branch_name}",
-      }
+  $src_branch_name = system::env('BRANCH')
+  $environment_prefix = system::env('ENVIRONMENT_PREFIX')
 
-      # Deploy the target environment associated with the feature branch
-      $deploy_code_result = cd4pe_deployments::deploy_code($target_environment)
-      $validate_code_deploy_result = cd4pe_deployments::validate_code_deploy_status($deploy_code_result)
-      if ($validate_code_deploy_result['error'] != undef) {
-        fail_plan($validate_code_deploy_result['error']['message'], $validate_code_deploy_result['error']['code'] )
-      }
+  if($repo_type == 'MODULE') {
+    $feature_branch_name = $src_branch_name
+    $base_branch_sha = system::env('CONTROL_REPO_BASE_FEATURE_BRANCH')
+    # Create a feature branch on the control repo based on the branch that was selected when the Deployment was added
+    # to the pipeline. Make the branch long lived.
+    $create_branch_result = cd4pe_deployments::create_git_branch('CONTROL_REPO', $feature_branch_name, $base_branch_sha, false)
+    if $create_branch_result['error'] != undef {
+      fail_plan($create_branch_result['error']['message'], $create_branch_result['error']['code'])
     }
-    default: {
-      fail_plan("Invalid repo type: ${repo_type}", 'InvalidRepoType')
-    }
+  }
+
+  # If an environment prefix was selected on the Deployment then calculate the target environment name with this prefix
+  $target_environment = $environment_prefix ? {
+    '' => $src_branch_name,
+    String[1] => "${environment_prefix}${src_branch_name}",
+  }
+
+  # Deploy the target environment associated with the feature branch
+  $deploy_code_result = cd4pe_deployments::deploy_code($target_environment)
+  $validate_code_deploy_result = cd4pe_deployments::validate_code_deploy_status($deploy_code_result)
+  if ($validate_code_deploy_result['error'] != undef) {
+    fail_plan($validate_code_deploy_result['error']['message'], $validate_code_deploy_result['error']['code'] )
   }
 }


### PR DESCRIPTION
Currently, we do not add the environment prefix if it exists in a control repo feature branch deployment. This rearranges some logic in the feature_branch.pp plan to make this logic universal for both modules and control repos