### PR TITLE
CDPE-3014 gets '$cd4pe_token' from system env

### DIFF
--- a/plans/cd4pe_job.pp
+++ b/plans/cd4pe_job.pp
@@ -2,14 +2,15 @@ plan cd4pe_deployments::cd4pe_job (
   TargetSpec                      $targets,
   String[1]                       $job_instance_id,
   String[1]                       $cd4pe_web_ui_endpoint,
-  String[1]                       $cd4pe_token,
   String[1]                       $cd4pe_job_owner,
   Optional[Array[String[1]]]      $env_vars = undef,
   Optional[String[1]]             $docker_image = undef,
   Optional[Array[String[1]]]      $docker_run_args = undef,
   Optional[String[1]]             $base_64_ca_cert = undef,
-
 ) {
+
+  $cd4pe_token = system::env('CD4PE_TOKEN')
+
   return run_task(
     'cd4pe_jobs::run_cd4pe_job',
     $targets,


### PR DESCRIPTION
Currently, when viewing a run of the cd4pe_job plan in the PE console, you can see the '$cd4pe_token' value plain as day. While this token only lasts the life of the task run, there is a small chance it could be used for something other than intended so we are changing the way we get it. Instead of it being passed to the plan as a param, we're going to set it in CD4PE and then get it from the environment in our plan. This change gets it using system::env().