### PR TITLE
(CDPE-3102) Fix git branch creation in the feature_branch policy plan

### DIFF
--- a/plans/feature_branch.pp
+++ b/plans/feature_branch.pp
@@ -14,7 +14,7 @@ plan cd4pe_deployments::feature_branch (
 
   if($repo_type == 'MODULE') {
     $feature_branch_name = $src_branch_name
-    $base_branch_sha = system::env('CONTROL_REPO_BASE_FEATURE_BRANCH')
+    $base_branch_sha = system::env('CONTROL_REPO_BASE_FEATURE_BRANCH_HEAD')
     # Create a feature branch on the control repo based on the branch that was selected when the Deployment was added
     # to the pipeline. Make the branch long lived.
     $create_branch_result = cd4pe_deployments::create_git_branch('CONTROL_REPO', $feature_branch_name, $base_branch_sha, false)


### PR DESCRIPTION
- Previously the feature_branch policy plan would use the branch name of
the base control repo when creating git branches for module deployments.
Some of CD4PE's supported VCS providers don't support creating branches
in this way and require a base SHA. Specifically, Github and Github
Enterprise require a SHA.
- Uses a newly added environment variable in CD4PE which contains the
HEAD SHA of the base control repo for a given module deployment.
- Tested with Github Enterprise and will test with all VCS providers
once I get some initial feedback.