### PR TITLE
(CDPE-2980) Add a 'fail_if_no_nodes' param to the direct policy

### DIFF
--- a/spec/plans/direct_spec.rb
+++ b/spec/plans/direct_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'rspec/mocks'
 require 'webmock/rspec'
 
-describe 'cd4pe_deployments::direct' do
+describe 'cd4pe_deployments::direct', if: Gem::Version.new(Puppet.version) >= Gem::Version.new('6.0.0') do
   context 'happy' do
     include_context 'deployment'
     let(:repo_type) { 'CONTROL_REPO' }

--- a/spec/plans/direct_spec.rb
+++ b/spec/plans/direct_spec.rb
@@ -1,0 +1,167 @@
+require 'spec_helper'
+require 'rspec/mocks'
+require 'webmock/rspec'
+
+describe 'cd4pe_deployments::direct' do
+  context 'happy' do
+    include_context 'deployment'
+    let(:repo_type) { 'CONTROL_REPO' }
+    let(:test_nodes) do
+      [
+        'foo.example.com',
+        'bar.example.com',
+        'biz.example.com',
+      ]
+    end
+
+    let(:puppet_run_request) do
+      {
+        environmentName: nil,
+        deploymentId: deployment_id,
+        nodes: test_nodes,
+        withNoop: false,
+      }
+    end
+
+    let(:run_puppet_response) do
+      {
+        'job' => {
+          'id' => 'https://test-pe:8143/orchestrator/v1/jobs/1',
+          'name' => '1',
+        },
+      }
+    end
+
+    let(:update_git_branch_response) do
+      {
+        'result' => {
+          'success' => true,
+        },
+        'error' => nil,
+      }
+    end
+
+    let(:node_group_response) do
+      {
+        'result' => {
+          'environment' => environment_name,
+          'nodes' => test_nodes,
+        },
+        'error' => nil,
+      }
+    end
+
+    let(:no_nodes_node_group_response) do
+      {
+        'result' => {
+          'environment' => environment_name,
+          'nodes' => nil,
+        },
+        'error' => nil,
+      }
+    end
+
+    let(:deploy_code_response) do
+      {
+        'result' =>
+        [
+          {
+            'environment' => 'development',
+            'id' => '40',
+            'status' => 'complete',
+            'deploySignature' => '6130590194c84c9aadc863e4af67ce788f59ab45',
+            'fileSync' => {
+              'environmentCommit' => '2e0ba4e305c7b39499bb8c2e62a1a07c5f22e3ee',
+              'codeCommit' => '350d908578ed214dc2465bdeae4459b6b625bb11',
+            },
+          },
+        ],
+        'error' => nil,
+      }
+    end
+
+    before(:each) do
+      stub_request(:get, ajax_url)
+        .with(query: { op: 'GetNodeGroupInfo', deploymentId: deployment_id, nodeGroupId: node_group_id }, headers: { 'authorization' => "Bearer token #{ENV['DEPLOYMENT_TOKEN']}" })
+        .to_return(body: JSON.generate(node_group_response['result']))
+        .times(1)
+
+      stub_request(:post, ajax_url)
+        .with(
+          body: {
+            op: 'UpdateGitRef',
+            content: {
+              repoType: repo_type,
+              deploymentId: deployment_id,
+              branchName: environment_name,
+              commitSha: commit,
+            },
+          },
+          headers: {
+            'authorization' => "Bearer token #{ENV['DEPLOYMENT_TOKEN']}",
+          },
+        )
+        .to_return(body: JSON.generate(update_git_branch_response['result']))
+        .times(1)
+
+      stub_request(:post, ajax_url)
+        .with(
+          headers: { 'content-type' => 'application/json', 'authorization' => "Bearer token #{ENV['DEPLOYMENT_TOKEN']}" },
+          body: {
+            op: 'SetDeploymentPendingApproval',
+            content: {
+              deploymentId: deployment_id,
+              environment: environment_name,
+            },
+          },
+        )
+        .to_return(body: JSON.generate(isPending: false))
+        .times(1)
+
+      stub_request(:post, ajax_url)
+        .with(
+          headers: { 'content-type' => 'application/json', 'authorization' => "Bearer token #{ENV['DEPLOYMENT_TOKEN']}" },
+          body: {
+            op: 'DeployCode',
+            content: { deploymentId: deployment_id, environmentName: environment_name },
+          },
+        )
+        .to_return(body: JSON.generate(deploy_code_response['result']), status: 200)
+        .times(1)
+
+      stub_request(:post, ajax_url)
+        .with(
+          headers: { 'content-type' => 'application/json', 'authorization' => "Bearer token #{ENV['DEPLOYMENT_TOKEN']}" },
+          body: {
+            op: 'RunPuppet',
+            content: puppet_run_request,
+          },
+        )
+        .to_return(body: JSON.generate(run_puppet_response), status: 200)
+        .times(1)
+
+      stub_request(:post, ajax_url)
+        .with(
+          headers: { 'content-type' => 'application/json', 'authorization' => "Bearer token #{ENV['DEPLOYMENT_TOKEN']}" },
+          body: {
+            op: 'GetPuppetRunStatus',
+            content: { deploymentId: deployment_id, jobId: run_puppet_response['job'] },
+          },
+        )
+        .to_return({ body: JSON.generate(state: 'running'), status: 200 }, body: JSON.generate(state: 'finished'), status: 200)
+        .times(2)
+    end
+
+    it 'runs the plan with default args' do
+      expect(run_plan('cd4pe_deployments::direct', {})).to be_ok
+    end
+
+    it 'runs the plan with fail_if_no_nodes disabled' do
+      stub_request(:get, ajax_url)
+        .with(query: { op: 'GetNodeGroupInfo', deploymentId: deployment_id, nodeGroupId: node_group_id }, headers: { 'authorization' => "Bearer token #{ENV['DEPLOYMENT_TOKEN']}" })
+        .to_return(body: JSON.generate(no_nodes_node_group_response['result']))
+        .times(1)
+      expect(run_plan('cd4pe_deployments::direct', 'fail_if_no_nodes' => false)).to be_ok
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,6 +32,7 @@ end
 
 RSpec.configure do |c|
   c.default_facts = default_facts
+  c.mock_with :rspec
   c.before :each do
     # set to strictest setting for testing
     # by default Puppet runs at warning level
@@ -58,6 +59,9 @@ RSpec.shared_context 'deployment' do
   let(:deployment_token) { '1234abcd' }
   let(:node_group_id) { 'aasdf-1234asdf-1234' }
   let(:environment_name) { 'development' }
+  let(:control_repo) { 'test_control_repo' }
+  let(:commit) { 'ef424ec352d4bc93317be901877e32f3c6a0289c' }
+  let(:git_branch) { 'src_development' }
   let(:ajax_url) { "#{test_host}/#{deployment_owner}/ajax" }
   let(:response) do
     {
@@ -85,6 +89,10 @@ RSpec.shared_context 'deployment' do
     ENV['DEPLOYMENT_ID'] = deployment_id
     ENV['DEPLOYMENT_TOKEN'] = deployment_token
     ENV['WEB_UI_ENDPOINT'] = test_host
+    ENV['REPO_TARGET_BRANCH'] = environment_name
+    ENV['COMMIT'] = commit
+    ENV['CONTROL_REPO'] = control_repo
+    ENV['NODE_GROUP_ID'] = node_group_id
   end
 end
 

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -1,0 +1,14 @@
+require 'puppet'
+# This file was copied from https://github.com/puppetlabs/puppetlabs-peadm/blob/master/spec/spec_helper_local.rb
+if Gem::Version.new(Puppet.version) >= Gem::Version.new('6.0.0')
+  begin
+    require 'bolt_spec/plans'
+    BoltSpec::Plans.init
+
+    # Seems to be needed to make `run_plan` available inside examples:
+    RSpec.configure { |c| c.include BoltSpec::Plans }
+  rescue LoadError => e
+    warn e.message
+    warn '=== bolt tests will not run; ensure bolt gem is installed (requires Puppet 6+)'
+  end
+end


### PR DESCRIPTION
- Previously, directly deployments would fail if the node group didn't
have any nodes. We had this problem with the rolling deployment policy
as well and have since added a param to optionally not fail. With this
change we've added the same parameter to the direct policy.
- Adds unit tests for the direct deployment policy itself using the
bolt_spec helper lib. This allows us to invoke the Bolt plan via an
rspec test. I haven't figured out how to mock/stub out Puppet functions
yet so we're currently stubbing out the underlying http requests made
for a given deployment. I'll happily move away from this pattern once I
figure out the mocking piece.
- Manually testing has also been performed with the param enabled/disabled.