### PR TITLE
(CDPE-2789) Add a function to list branches for deployment repo

### DIFF
--- a/lib/puppet/functions/cd4pe_deployments/get_git_branches.rb
+++ b/lib/puppet/functions/cd4pe_deployments/get_git_branches.rb
@@ -1,0 +1,37 @@
+require 'puppet_x/puppetlabs/cd4pe_client'
+require 'puppet_x/puppetlabs/cd4pe_function_result'
+
+# @summary Lists git branches for a repository associated with the current deployment
+Puppet::Functions.create_function(:'cd4pe_deployments::get_git_branches') do
+  # @param repo_type
+  #   The type of repo to perform the operation on. Must be one of "CONTROL_REPO" or "MODULE".
+  # @example List all branches for the control repo associated with the current deployment
+  #   $branches = cd4pe_deployments::get_git_branches('CONTROL_REPO')
+  #   $branches.each |$branch| { out::message("Branch name: ${branch['name']} Head SHA: ${branch['sha']}") }
+  # @return [Hash] contains the results of the function
+  #   See [README.md]() for information on the CD4PEFunctionResult hash format
+  #   * result [Array] a list of git branches:
+  #     * [Hash] a hash containing branch information
+  #       * name [String] the name of the branch
+  #       * sha  [String] the head SHA of the branch
+  #   * error [Hash] contains error information if any
+  dispatch :get_git_branches do
+    required_param 'Enum["CONTROL_REPO", "MODULE"]', :repo_type
+  end
+
+  def get_git_branches(repo_type)
+    client = PuppetX::Puppetlabs::CD4PEClient.new
+
+    response = client.get_git_branches(repo_type)
+    case response
+    when Net::HTTPSuccess
+      response_body = JSON.parse(response.body, symbolize_names: false)
+      return PuppetX::Puppetlabs::CD4PEFunctionResult.create_result(response_body)
+    when Net::HTTPClientError
+      response_body = JSON.parse(response.body, symbolize_names: false)
+      return PuppetX::Puppetlabs::CD4PEFunctionResult.create_error_result(response_body)
+    when Net::HTTPServerError
+      raise Puppet::Error "Unknown HTTP Error with code: #{response.code} and body #{response.body}"
+    end
+  end
+end

--- a/lib/puppet_x/puppetlabs/cd4pe_client.rb
+++ b/lib/puppet_x/puppetlabs/cd4pe_client.rb
@@ -160,6 +160,12 @@ module PuppetX::Puppetlabs
       make_request(:post, @owner_ajax_path, payload.to_json)
     end
 
+    def get_git_branches(repo_type)
+      query = "?op=GetGitBranches&deploymentId=#{@config[:deployment_id]}&repoType=#{repo_type}"
+      complete_path = @owner_ajax_path + query
+      make_request(:get, complete_path)
+    end
+
     private
 
     def deployment_token

--- a/spec/functions/cd4pe/get_git_branches_spec.rb
+++ b/spec/functions/cd4pe/get_git_branches_spec.rb
@@ -1,0 +1,38 @@
+
+require 'spec_helper'
+require_relative '../../../lib/puppet/functions/cd4pe_deployments/get_git_branches'
+require 'webmock/rspec'
+
+describe 'cd4pe_deployments::get_git_branches' do
+  context 'happy' do
+    include_context 'deployment'
+    let(:repo_type) { 'CONTROL_REPO' }
+    let(:expected_function_result) do
+      {
+        'result' =>
+        [
+          { 'name' => 'test_branch1', 'sha' => '12345' },
+          { 'name' => 'test_branch2', 'sha' => '12345' },
+          { 'name' => 'test_branch3', 'sha' => '12345' },
+        ],
+        'error' => nil,
+      }
+    end
+
+    it 'succeeds with parameters' do
+      stub_request(:get, ajax_url)
+        .with(query: { op: 'GetGitBranches', deploymentId: deployment_id, repoType: repo_type }, headers: { 'authorization' => "Bearer token #{ENV['DEPLOYMENT_TOKEN']}" })
+        .to_return(body: JSON.generate(expected_function_result['result']))
+        .times(1)
+      is_expected.to run.with_params(repo_type).and_return(expected_function_result)
+    end
+    it 'returns a non-200 response code' do
+      stub_request(:get, ajax_url)
+        .with(query: { op: 'GetGitBranches', deploymentId: deployment_id, repoType: repo_type }, headers: { 'authorization' => "Bearer token #{ENV['DEPLOYMENT_TOKEN']}" })
+        .to_return(body: JSON.generate(error_response), status: 404)
+        .times(1)
+
+      is_expected.to run.with_params(repo_type).and_return(error_response)
+    end
+  end
+end


### PR DESCRIPTION
- Previously, users could create and delete branches via the deployment
related Puppet functions, but there was no way to list available branches
 for a given repository associated with a deployment.
- Adds a new function to allow users to list git branches for a repo
associated with a deployment. It's possible to list branches for the
control repo or module repo. The reason this is specified at all is
because a module deployment is associated with a repository, but can
also be associated with a control repo which is why the function takes
the repo type as an argument.
- In addition to the tests added here, The underlying CD4PE API has
 been manually tested with every  VCS provider.