### PR TITLE
(CDPE-3193) Perform a code deploy after rolling deployment

### DIFF
--- a/plans/rolling.pp
+++ b/plans/rolling.pp
@@ -131,6 +131,12 @@ plan cd4pe_deployments::rolling (
     fail_plan("Unable to update the target branch ${target_branch} to SHA ${sha}")
   }
 
+  $code_result = cd4pe_deployments::deploy_code($target_environment)
+  $validate_code_deploy_result = cd4pe_deployments::validate_code_deploy_status($code_result)
+  unless ($validate_code_deploy_result[error] =~ Undef) {
+    fail_plan("Code deployment failed to target environment ${target_environment}: ${validate_code_deploy_result[error][message]}")
+  }
+
   # Clean up the temporary temporary node group
   $delete_tmp_node_group_result = cd4pe_deployments::delete_node_group($child_group[result][id])
   if ($delete_tmp_node_group_result[error]) {


### PR DESCRIPTION
Previous to this commit, after a rolling deployment is completed, we
would perform a merge and delete the temp environment, but not deploy
the final merged code. This would cause the agents on their next run to
revert to the previous code, causing production outages.

This commit fixes the issue by performed the code deploy right after the
code is merged, but before any other operations to reduce risk of
failures leaving code un-deployed.