### PR TITLE
CDPE-3065 updates README for new deployment env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ This module provides a set of tools, via CD4PE, for creating your own custom CD4
 1. Get started with a custom deployment policy by creating a [Puppet Plan] in the `plans/` directory.
 2. You'll have access to all of the functions listed in our [REFERENCE.md] to perform deployment operations (e.g. pinning nodes to an environment group or getting information about an environment group)
 3. Deployment policies will run inside a CD4PE context with certain environment variables available.
+    * `MODULE_NAME`: the name of the module being deployed 
+    * `CONTROL_REPO_NAME`: the name of the control repo being deployed. In the case of a module feature branch deployment, this is the name of the control repo the deployment is based off of.
     * `BRANCH`: the name of the branch you are deploying _from_; your pipeline branch
     * `COMMIT`: HEAD commit SHA of the branch you are deploying from
     * `NODE_GROUP_ID`: alpha-numberic ID of the node group you are deploying _to_


### PR DESCRIPTION
As part of the work for CDPE-3065, this change adds information about 2 new env vars that are available to custom deployments: MODULE_NAME and CONTROL_REPO_NAME