### PR TITLE
(CDPE-3239) Add functions for pipeline reporting

### DIFF
--- a/functions/evaluate_result.pp
+++ b/functions/evaluate_result.pp
@@ -1,0 +1,12 @@
+# @summary This is a generic helper function to be used with the result from cd4pe_deployments function calls.
+#          It will take the result from the function call and return an error hash if an error occurred. If no
+#          error occurred, the result is returned, saving the user from having to process the hash.
+# @param [Hash] result_hash
+#   The result hash of any cd4pe_deployments function call.
+# @return [Variant] contains the results of the function
+function cd4pe_deployments::evaluate_result(Hash $result_hash){
+  if $result_hash['error'] =~ NotUndef {
+    fail_plan($result_hash['error']['message'], $result_hash['error']['code'])
+  }
+  $result_hash['result']
+}

--- a/functions/validate_code_deploy_status.pp
+++ b/functions/validate_code_deploy_status.pp
@@ -1,9 +1,10 @@
 # @summary This is a helper function to be used with the result from the `deploy_code` function.
 #          It will take the result from a code deploy and return an error hash if an error occurred or if
 #          any of the code deployments failed.
-# @param [Hash] $deploy_code_result
+# @param [Hash] deploy_code_result
 #   The results of the code deployment from calling the `deploy_code` function.
 #   See the `deploy_code` docs for more info on the value of this object
+# @return [Hash] contains the results of the code deployment
 function cd4pe_deployments::validate_code_deploy_status(Hash $deploy_code_result) {
 
   # If the deploy_code_result contains an error Hash then just return it as the error

--- a/lib/puppet/functions/cd4pe_deployments/get_cookie.rb
+++ b/lib/puppet/functions/cd4pe_deployments/get_cookie.rb
@@ -1,0 +1,38 @@
+require 'puppet_x/puppetlabs/cd4pe_client'
+require 'puppet_x/puppetlabs/cd4pe_function_result'
+
+# @summary Get a CD4PE cookie to use APIs that don't support token auth
+Puppet::Functions.create_function(:'cd4pe_deployments::get_cookie') do
+  # @param login_user
+  #   The CD4PE user login (email address)
+  # @param login_pwd
+  #   The CD4PE user password
+  # @example Get a cookie
+  #   $cookie = get_cookie('user@domain.com', 'P@ssw0rd')
+  # @return [Hash] contains the results of the function
+  #   See [README.md]() for information on the CD4PEFunctionResult hash format
+  #   * result [String] the cookie value
+  #   * error [Hash] contains error information if any
+  #
+  dispatch :get_cookie do
+    required_param 'String', :login_user
+    required_param 'String', :login_pwd
+  end
+
+  def get_cookie(login_user, login_pwd)
+    client = PuppetX::Puppetlabs::CD4PEClient.new
+
+    response = client.get_cookie(login_user, login_pwd)
+    if response.code == '200'
+      return PuppetX::Puppetlabs::CD4PEFunctionResult.create_result(response['Set-Cookie'])
+
+    elsif response.code =~ %r{4[0-9]+}
+      response_body = JSON.parse(response.body, symbolize_names: false)
+      return PuppetX::Puppetlabs::CD4PEFunctionResult.create_error_result(response_body)
+    else
+      raise Puppet::Error "Unknown HTTP Error with code: #{response.code} and body #{response.body}"
+    end
+  rescue => exception
+    PuppetX::Puppetlabs::CD4PEFunctionResult.create_exception_result(exception)
+  end
+end

--- a/lib/puppet/functions/cd4pe_deployments/get_impact_analysis.rb
+++ b/lib/puppet/functions/cd4pe_deployments/get_impact_analysis.rb
@@ -1,0 +1,35 @@
+require 'puppet_x/puppetlabs/cd4pe_client'
+require 'puppet_x/puppetlabs/cd4pe_function_result'
+
+# @summary Get information about a CD4PE Impact Analysis
+Puppet::Functions.create_function(:'cd4pe_deployments::get_impact_analysis') do
+  # @param id
+  #   The internal ID of the Impact Analysis
+  # @example Get information about an Impact Analysis
+  #   $ia = get_impact_analysis(2452)
+  # @return [Hash] contains the results of the function
+  #   See [README.md]() for information on the CD4PEFunctionResult hash format
+  #   * result [Hash] of GetImpactAnalysis operation
+  #   * error [Hash] contains error information if any
+  #
+  dispatch :get_impact_analysis do
+    required_param 'Integer', :id
+  end
+
+  def get_impact_analysis(id)
+    client = PuppetX::Puppetlabs::CD4PEClient.new
+
+    response = client.get_impact_analysis(id)
+    if response.code == '200'
+      response_body = JSON.parse(response.body, symbolize_names: false)
+      PuppetX::Puppetlabs::CD4PEFunctionResult.create_result(response_body)
+    elsif response.code =~ %r{4[0-9]+}
+      response_body = JSON.parse(response.body, symbolize_names: false)
+      PuppetX::Puppetlabs::CD4PEFunctionResult.create_error_result(response_body)
+    else
+      raise Puppet::Error "Unknown HTTP Error with code: #{response.code} and body #{response.body}"
+    end
+  rescue => exception
+    PuppetX::Puppetlabs::CD4PEFunctionResult.create_exception_result(exception)
+  end
+end

--- a/lib/puppet/functions/cd4pe_deployments/get_impact_analysis.rb
+++ b/lib/puppet/functions/cd4pe_deployments/get_impact_analysis.rb
@@ -20,16 +20,15 @@ Puppet::Functions.create_function(:'cd4pe_deployments::get_impact_analysis') do
     client = PuppetX::Puppetlabs::CD4PEClient.new
 
     response = client.get_impact_analysis(id)
-    if response.code == '200'
+    case response
+    when Net::HTTPSuccess
       response_body = JSON.parse(response.body, symbolize_names: false)
       PuppetX::Puppetlabs::CD4PEFunctionResult.create_result(response_body)
-    elsif response.code =~ %r{4[0-9]+}
+    when Net::HTTPClientError
       response_body = JSON.parse(response.body, symbolize_names: false)
       PuppetX::Puppetlabs::CD4PEFunctionResult.create_error_result(response_body)
-    else
+    when Net::HTTPServerError
       raise Puppet::Error "Unknown HTTP Error with code: #{response.code} and body #{response.body}"
     end
-  rescue => exception
-    PuppetX::Puppetlabs::CD4PEFunctionResult.create_exception_result(exception)
   end
 end

--- a/lib/puppet/functions/cd4pe_deployments/get_pipeline.rb
+++ b/lib/puppet/functions/cd4pe_deployments/get_pipeline.rb
@@ -33,16 +33,15 @@ Puppet::Functions.create_function(:'cd4pe_deployments::get_pipeline') do
 
     client = PuppetX::Puppetlabs::CD4PEClient.new
     response = client.get_pipeline(repo_type, repo_name, pipeline_id)
-    if response.code == '200'
+    case response
+    when Net::HTTPSuccess
       response_body = JSON.parse(response.body, symbolize_names: false)
       PuppetX::Puppetlabs::CD4PEFunctionResult.create_result(response_body)
-    elsif response.code =~ %r{4[0-9]+}
+    when Net::HTTPClientError
       response_body = JSON.parse(response.body, symbolize_names: false)
       PuppetX::Puppetlabs::CD4PEFunctionResult.create_error_result(response_body)
-    else
+    when Net::HTTPServerError
       raise Puppet::Error "Unknown HTTP Error with code: #{response.code} and body #{response.body}"
     end
-  rescue => exception
-    PuppetX::Puppetlabs::CD4PEFunctionResult.create_exception_result(exception)
   end
 end

--- a/lib/puppet/functions/cd4pe_deployments/get_pipeline.rb
+++ b/lib/puppet/functions/cd4pe_deployments/get_pipeline.rb
@@ -1,0 +1,48 @@
+require 'puppet_x/puppetlabs/cd4pe_client'
+require 'puppet_x/puppetlabs/cd4pe_function_result'
+
+# @summary Get information about a CD4PE pipeline
+Puppet::Functions.create_function(:'cd4pe_deployments::get_pipeline') do
+  # @param repo_type
+  #   The type of the repository (CONTROL_REPO or MODULE)
+  # @param repo_name
+  #   The name of the repository
+  # @param pipeline_id
+  #   The internal ID of the pipeline for this repository
+  # @example Get information about a specific pipeline for 'control-repo'
+  #   $pipeline = get_pipeline('CONTROL_REPO', 'control-repo', '14hf24zme79k00mcrknrbt23sb')
+  # @return [Hash] contains the results of the function
+  #   See [README.md]() for information on the CD4PEFunctionResult hash format
+  #   * result [Hash]:
+  #     * `buildStage [String] info on the git change`
+  #     * `id [String] the pipeline's id`
+  #     * `name [String] the name of the pipeline`
+  #     * `projectId [Hash] internal naming of the CD4PE repo`
+  #     * `sources [Array] information about the source triggering the pipeline`
+  #     * `stages [Array] information about all the stages in the pipeline, and their items`
+  #   * error [Hash] contains error information if any
+  #
+  dispatch :get_pipeline do
+    required_param 'String', :repo_type
+    required_param 'String', :repo_name
+    required_param 'String', :pipeline_id
+  end
+
+  def get_pipeline(repo_type, repo_name, pipeline_id)
+    raise Puppet::Error "Invalid repo_type specified: #{repo_type}" unless ['CONTROL_REPO', 'MODULE'].include?(repo_type)
+
+    client = PuppetX::Puppetlabs::CD4PEClient.new
+    response = client.get_pipeline(repo_type, repo_name, pipeline_id)
+    if response.code == '200'
+      response_body = JSON.parse(response.body, symbolize_names: false)
+      PuppetX::Puppetlabs::CD4PEFunctionResult.create_result(response_body)
+    elsif response.code =~ %r{4[0-9]+}
+      response_body = JSON.parse(response.body, symbolize_names: false)
+      PuppetX::Puppetlabs::CD4PEFunctionResult.create_error_result(response_body)
+    else
+      raise Puppet::Error "Unknown HTTP Error with code: #{response.code} and body #{response.body}"
+    end
+  rescue => exception
+    PuppetX::Puppetlabs::CD4PEFunctionResult.create_exception_result(exception)
+  end
+end

--- a/lib/puppet/functions/cd4pe_deployments/get_pipeline_trigger_event.rb
+++ b/lib/puppet/functions/cd4pe_deployments/get_pipeline_trigger_event.rb
@@ -1,0 +1,42 @@
+require 'puppet_x/puppetlabs/cd4pe_client'
+require 'puppet_x/puppetlabs/cd4pe_function_result'
+
+# @summary Search which recent pipeline(s) match for a given commit SHA for a repository
+Puppet::Functions.create_function(:'cd4pe_deployments::get_pipeline_trigger_event') do
+  # @param repo_name
+  #   The name of the repository
+  # @param pipeline_id
+  #   The pipelineId of the pipeline
+  # @param commit_sha
+  #   The commit SHA to get the pipeline result for
+  # @example Get pipeline trigger event for a repository named 'control-repo'
+  #   $pipeline = get_pipeline_trigger_event('control-repo', '1mfxk3kc4ic1w0nny0zcq5l7cw', '47b552dc15448b4e306fcf8df320e5124b2cbd63')
+  # @return [Hash] contains the results of the function
+  #   See [README.md]() for information on the CD4PEFunctionResult hash format
+  #   * result [Hash]:
+  #     * `rows [Array] array of hashes with pipeline results. Contains 1 hash for the result of the matching commit SHA`
+  #   * error [Hash] contains error information if any
+  #
+  dispatch :get_pipeline_trigger_event do
+    required_param 'String', :repo_name
+    required_param 'String', :pipeline_id
+    required_param 'String', :commit_sha
+  end
+
+  def get_pipeline_trigger_event(repo_name, pipeline_id, commit_sha)
+    client = PuppetX::Puppetlabs::CD4PEClient.new
+
+    response = client.list_trigger_events(repo_name, pipeline_id, commit_sha)
+    if response.code == '200'
+      response_body = JSON.parse(response.body, symbolize_names: false)
+      PuppetX::Puppetlabs::CD4PEFunctionResult.create_result(response_body['rows'].first)
+    elsif response.code =~ %r{4[0-9]+}
+      response_body = JSON.parse(response.body, symbolize_names: false)
+      PuppetX::Puppetlabs::CD4PEFunctionResult.create_error_result(response_body)
+    else
+      raise Puppet::Error "Unknown HTTP Error with code: #{response.code} and body #{response.body}"
+    end
+  rescue => exception
+    PuppetX::Puppetlabs::CD4PEFunctionResult.create_exception_result(exception)
+  end
+end

--- a/lib/puppet/functions/cd4pe_deployments/get_pipeline_trigger_event.rb
+++ b/lib/puppet/functions/cd4pe_deployments/get_pipeline_trigger_event.rb
@@ -27,16 +27,15 @@ Puppet::Functions.create_function(:'cd4pe_deployments::get_pipeline_trigger_even
     client = PuppetX::Puppetlabs::CD4PEClient.new
 
     response = client.list_trigger_events(repo_name, pipeline_id, commit_sha)
-    if response.code == '200'
+    case response
+    when Net::HTTPSuccess
       response_body = JSON.parse(response.body, symbolize_names: false)
       PuppetX::Puppetlabs::CD4PEFunctionResult.create_result(response_body['rows'].first)
-    elsif response.code =~ %r{4[0-9]+}
+    when Net::HTTPClientError
       response_body = JSON.parse(response.body, symbolize_names: false)
       PuppetX::Puppetlabs::CD4PEFunctionResult.create_error_result(response_body)
-    else
+    when Net::HTTPServerError
       raise Puppet::Error "Unknown HTTP Error with code: #{response.code} and body #{response.body}"
     end
-  rescue => exception
-    PuppetX::Puppetlabs::CD4PEFunctionResult.create_exception_result(exception)
   end
 end

--- a/lib/puppet/functions/cd4pe_deployments/search_impacted_nodes.rb
+++ b/lib/puppet/functions/cd4pe_deployments/search_impacted_nodes.rb
@@ -1,0 +1,36 @@
+require 'puppet_x/puppetlabs/cd4pe_client'
+require 'puppet_x/puppetlabs/cd4pe_function_result'
+
+# @summary Get information about the impacted nodes of a CD4PE Impact Analysis
+Puppet::Functions.create_function(:'cd4pe_deployments::search_impacted_nodes') do
+  # @param environment_result_id
+  #   The internal environment_result_id of an analysed code environment in the IA
+  # @example Get information about a specific environment in a specific IA
+  #   $impacted_nodes = search_impacted_nodes(517)
+  # @return [Hash] contains the results of the function
+  #   See [README.md]() for information on the CD4PEFunctionResult hash format
+  #   * result [Hash]:
+  #     * `rows [Array] array of hashes, one for each impacted node`
+  #   * error [Hash] contains error information if any
+  #
+  dispatch :search_impacted_nodes do
+    required_param 'Integer', :environment_result_id
+  end
+
+  def search_impacted_nodes(environment_result_id)
+    client = PuppetX::Puppetlabs::CD4PEClient.new
+
+    response = client.search_impacted_nodes(environment_result_id)
+    if response.code == '200'
+      response_body = JSON.parse(response.body, symbolize_names: false)
+      PuppetX::Puppetlabs::CD4PEFunctionResult.create_result(response_body)
+    elsif response.code =~ %r{4[0-9]+}
+      response_body = JSON.parse(response.body, symbolize_names: false)
+      PuppetX::Puppetlabs::CD4PEFunctionResult.create_error_result(response_body)
+    else
+      raise Puppet::Error "Unknown HTTP Error with code: #{response.code} and body #{response.body}"
+    end
+  rescue => exception
+    PuppetX::Puppetlabs::CD4PEFunctionResult.create_exception_result(exception)
+  end
+end

--- a/lib/puppet/functions/cd4pe_deployments/search_impacted_nodes.rb
+++ b/lib/puppet/functions/cd4pe_deployments/search_impacted_nodes.rb
@@ -21,16 +21,15 @@ Puppet::Functions.create_function(:'cd4pe_deployments::search_impacted_nodes') d
     client = PuppetX::Puppetlabs::CD4PEClient.new
 
     response = client.search_impacted_nodes(environment_result_id)
-    if response.code == '200'
+    case response
+    when Net::HTTPSuccess
       response_body = JSON.parse(response.body, symbolize_names: false)
       PuppetX::Puppetlabs::CD4PEFunctionResult.create_result(response_body)
-    elsif response.code =~ %r{4[0-9]+}
+    when Net::HTTPClientError
       response_body = JSON.parse(response.body, symbolize_names: false)
       PuppetX::Puppetlabs::CD4PEFunctionResult.create_error_result(response_body)
-    else
+    when Net::HTTPServerError
       raise Puppet::Error "Unknown HTTP Error with code: #{response.code} and body #{response.body}"
     end
-  rescue => exception
-    PuppetX::Puppetlabs::CD4PEFunctionResult.create_exception_result(exception)
   end
 end

--- a/lib/puppet/functions/cd4pe_deployments/search_pipeline.rb
+++ b/lib/puppet/functions/cd4pe_deployments/search_pipeline.rb
@@ -1,0 +1,42 @@
+require 'puppet_x/puppetlabs/cd4pe_client'
+require 'puppet_x/puppetlabs/cd4pe_function_result'
+
+# @summary Search which recent pipeline(s) match for a given commit SHA for a repository
+Puppet::Functions.create_function(:'cd4pe_deployments::search_pipeline') do
+  # @param repo_name
+  #   The name of the repository
+  # @param commit_sha
+  #   The commit SHA to get the pipeline result for
+  # @example List recent trigger events for a repository named 'control-repo'
+  #   $pipeline = search_pipeline('control-repo', '47b552dc15448b4e306fcf8df320e5124b2cbd63')
+  # @return [Hash] contains the results of the function
+  #   See [README.md]() for information on the CD4PEFunctionResult hash format
+  #   * result [String]: the pipelineId of the found pipeline for the provided commit SHA
+  #   * error [Hash] contains error information if any
+  #
+  dispatch :search_pipeline do
+    required_param 'String', :repo_name
+    required_param 'String', :commit_sha
+  end
+
+  def search_pipeline(repo_name, commit_sha)
+    client = PuppetX::Puppetlabs::CD4PEClient.new
+
+    response = client.list_trigger_events(repo_name)
+    if response.code == '200'
+      response_body = JSON.parse(response.body, symbolize_names: false)
+      response_body['rows'].each do |row|
+        next unless row['commitId'] == commit_sha
+
+        return PuppetX::Puppetlabs::CD4PEFunctionResult.create_result(row['pipelineId'])
+      end
+    elsif response.code =~ %r{4[0-9]+}
+      response_body = JSON.parse(response.body, symbolize_names: false)
+      PuppetX::Puppetlabs::CD4PEFunctionResult.create_error_result(response_body)
+    else
+      raise Puppet::Error "Unknown HTTP Error with code: #{response.code} and body #{response.body}"
+    end
+  rescue => exception
+    PuppetX::Puppetlabs::CD4PEFunctionResult.create_exception_result(exception)
+  end
+end

--- a/lib/puppet_x/puppetlabs/cd4pe_client.rb
+++ b/lib/puppet_x/puppetlabs/cd4pe_client.rb
@@ -65,7 +65,7 @@ module PuppetX::Puppetlabs
       make_request(:post, @owner_ajax_path, payload.to_json)
     end
 
-    def get_approval_state # rubocop:disable Naming/AccessorMethodName
+    def get_approval_state # rubocop:disable Style/AccessorMethodName
       query = "?op=GetDeploymentApprovalState&deploymentId=#{deployment_id}"
       complete_path = @owner_ajax_path + query
       make_request(:get, complete_path)

--- a/plans/direct.pp
+++ b/plans/direct.pp
@@ -9,6 +9,8 @@
 #     The number of allowed failed Puppet runs that can occur before the Deployment will fail
 # @param noop
 #     Indicates if the Puppet run should be a noop.
+# @param fail_if_no_nodes
+#     Toggles between failing or silently succeeding when the target environment group has no nodes.
 plan cd4pe_deployments::direct (
   Integer $max_node_failure = 0,
   Boolean $noop = false,

--- a/plans/rolling.pp
+++ b/plans/rolling.pp
@@ -10,7 +10,16 @@
 #
 # @summary This deployment policy will deploy the target control repository commit to
 #          target nodes in batches.
-#
+# @param max_node_failure
+#     The number of allowed failed Puppet runs that can occur before the Deployment will fail
+# @param batch_size
+#     The number of nodes in each batch to run Puppet on.
+# @param noop
+#     Indicates if the Puppet run should be a noop.
+# @param batch_delay
+#     The delay in seconds between each batch.
+# @param fail_if_no_nodes
+#     Toggles between failing or silently succeeding when the target environment group has no nodes.
 plan cd4pe_deployments::rolling (
   Optional[Integer] $max_node_failure,
   Integer $batch_size = 10,


### PR DESCRIPTION
This PR adds new functions to enable dynamic reporting of the pipeline while it's running:
- `cd4pe_deployments::get_impact_analysis` adds the ability to get the environments analyzed by IA
- `cd4pe_deployments::get_pipeline` adds the ability to get the last run result for a specific pipeline
- `cd4pe_deployments::get_pipeline_trigger_event` adds the ability to get the run result for a recently run pipeline, by pipeline ID and commit SHA
- `cd4pe_deployments::search_impacted_nodes` adds the ability to get the detailed impact on individual nodes from an IA
- `cd4pe_deployments::search_pipeline` adds the ability to get the pipeline ID for a pipeline that was triggered on a specific commit SHA
- `cd4pe_deployments::get_cookie` adds the ability to generate a CD4PE cookie from basic auth, to interact with API operations that do not allow token auth at this point (even though the added functions do all use token auth now)

This PR contains updates to `cd4pe_client.rb` to allow all the above functions to work properly. It also contains some minor rubocop fixes.