### PR TITLE
(CDPE-3219) Do not allow negative max_node_failure

### DIFF
--- a/plans/direct.pp
+++ b/plans/direct.pp
@@ -12,9 +12,9 @@
 # @param fail_if_no_nodes
 #     Toggles between failing or silently succeeding when the target environment group has no nodes.
 plan cd4pe_deployments::direct (
-  Integer $max_node_failure = 0,
-  Boolean $noop = false,
-  Boolean $fail_if_no_nodes = true,
+  Integer[0] $max_node_failure = 0,
+  Boolean    $noop = false,
+  Boolean    $fail_if_no_nodes = true,
 ) {
   $repo_target_branch = system::env('REPO_TARGET_BRANCH')
   $source_commit = system::env('COMMIT')


### PR DESCRIPTION
Prior to this commit, max_node_failure could be specified as a negative number which doesn't make any sense.

After this commit, max_node_failure must be 0 or more.