### PR TITLE
(CDPE-3353) Prevent repeat deployment approval pending states

### DIFF
--- a/lib/puppet/functions/cd4pe_deployments/wait_for_approval.rb
+++ b/lib/puppet/functions/cd4pe_deployments/wait_for_approval.rb
@@ -41,7 +41,7 @@ Puppet::Functions.create_function(:'cd4pe_deployments::wait_for_approval') do
     # state, then we should enter the rest of the wait_for_approval function.
     # However, any other state should be returned immediately so the deployment
     # can continue
-    unless state['result'].empty? and state['result']['isPending']
+    unless state['result'].empty? && state['result']['isPending']
       return state unless state['result'].empty?
     end
 

--- a/lib/puppet/functions/cd4pe_deployments/wait_for_approval.rb
+++ b/lib/puppet/functions/cd4pe_deployments/wait_for_approval.rb
@@ -33,7 +33,17 @@ Puppet::Functions.create_function(:'cd4pe_deployments::wait_for_approval') do
 
     state = approval_state
     return state unless state['error'].nil?
-    return state unless state['result'].empty?
+
+    # When the wait_for_approval function is run, the expected state
+    # of the deployment's approval is nothing. However, it could also
+    # be in a pending, approved, or declined state from a previous call
+    # to wait_for_approval(). If the deployment is already in a pending
+    # state, then we should enter the rest of the wait_for_approval function.
+    # However, any other state should be returned immediately so the deployment
+    # can continue
+    unless state['result'].empty? and state['result']['isPending']
+      return state unless state['result'].empty?
+    end
 
     # Set the approval to pending and return if the result is anything other
     # than a pending state

--- a/lib/puppet/functions/cd4pe_deployments/wait_for_approval.rb
+++ b/lib/puppet/functions/cd4pe_deployments/wait_for_approval.rb
@@ -41,7 +41,7 @@ Puppet::Functions.create_function(:'cd4pe_deployments::wait_for_approval') do
     # state, then we should enter the rest of the wait_for_approval function.
     # However, any other state should be returned immediately so the deployment
     # can continue
-    unless state['result'].empty? && state['result']['isPending']
+    if !(state['result'].empty?) && !(state['result']['isPending'])
       return state
     end
 

--- a/lib/puppet/functions/cd4pe_deployments/wait_for_approval.rb
+++ b/lib/puppet/functions/cd4pe_deployments/wait_for_approval.rb
@@ -38,12 +38,10 @@ Puppet::Functions.create_function(:'cd4pe_deployments::wait_for_approval') do
     #   approval step. If not, create the deployment approval in the backend
     #   and set it to pending
     state = approval_decision(approval_response)
-    if ['APPROVED', 'DECLINED'].include?(state)
-      return approval_response
-    else
-      approval_response = attempt_set_deployment_pending(environment_name)
-      return response unless response['result']['isPending']
-    end
+    return approval_response if ['APPROVED', 'DECLINED'].include?(state)
+
+    approval_response = attempt_set_deployment_pending(environment_name)
+    return response unless response['result']['isPending']
 
     if approval_response['result'].empty? # rubocop:disable Style/GuardClause
       url = approval_url

--- a/lib/puppet/functions/cd4pe_deployments/wait_for_approval.rb
+++ b/lib/puppet/functions/cd4pe_deployments/wait_for_approval.rb
@@ -42,7 +42,7 @@ Puppet::Functions.create_function(:'cd4pe_deployments::wait_for_approval') do
     # However, any other state should be returned immediately so the deployment
     # can continue
     unless state['result'].empty? && state['result']['isPending']
-      return state unless state['result'].empty?
+      return state
     end
 
     # Set the approval to pending and return if the result is anything other

--- a/spec/plans/direct_spec.rb
+++ b/spec/plans/direct_spec.rb
@@ -29,7 +29,7 @@ describe 'cd4pe_deployments::direct', if: Gem::Version.new(Puppet.version) >= Ge
           'isPending' => false,
           'approvalDecision' => 'APPROVED',
         },
-        'error' => nil
+        'error' => nil,
       }
     end
 

--- a/spec/plans/direct_spec.rb
+++ b/spec/plans/direct_spec.rb
@@ -27,7 +27,7 @@ describe 'cd4pe_deployments::direct', if: Gem::Version.new(Puppet.version) >= Ge
       {
         'result' => {
           'isPending' => false,
-          'approvalDecision' => 'APPROVED'
+          'approvalDecision' => 'APPROVED',
         },
         'error' => nil
       }
@@ -37,18 +37,18 @@ describe 'cd4pe_deployments::direct', if: Gem::Version.new(Puppet.version) >= Ge
       {
         'result' => {
           'isPending' => false,
-          'approvalDecision' => 'DECLINED'
+          'approvalDecision' => 'DECLINED',
         },
-        'error' => nil
+        'error' => nil,
       }
     end
 
     let(:approval_pending_response) do
       {
         'result' => {
-          'isPending' => true
+          'isPending' => true,
         },
-        'error' => nil
+        'error' => nil,
       }
     end
 
@@ -116,7 +116,7 @@ describe 'cd4pe_deployments::direct', if: Gem::Version.new(Puppet.version) >= Ge
         .times(1)
 
       stub_request(:get, ajax_url)
-        .with(query: { op: 'GetDeploymentApprovalState', deploymentId: deployment_id},  headers: { 'authorization'=>"Bearer token #{ENV['DEPLOYMENT_TOKEN']}" })
+        .with(query: { op: 'GetDeploymentApprovalState', deploymentId: deployment_id }, headers: { 'authorization' => "Bearer token #{ENV['DEPLOYMENT_TOKEN']}" })
         .to_return(body: JSON.generate(approval_pending_response['result']))
 
       stub_request(:post, ajax_url)

--- a/spec/plans/direct_spec.rb
+++ b/spec/plans/direct_spec.rb
@@ -23,6 +23,35 @@ describe 'cd4pe_deployments::direct', if: Gem::Version.new(Puppet.version) >= Ge
       }
     end
 
+    let(:deployment_approved_response) do
+      {
+        'result' => {
+          'isPending' => false,
+          'approvalDecision' => 'APPROVED'
+        },
+        'error' => nil
+      }
+    end
+
+    let(:deployment_declined_response) do
+      {
+        'result' => {
+          'isPending' => false,
+          'approvalDecision' => 'DECLINED'
+        },
+        'error' => nil
+      }
+    end
+
+    let(:approval_pending_response) do
+      {
+        'result' => {
+          'isPending' => true
+        },
+        'error' => nil
+      }
+    end
+
     let(:run_puppet_response) do
       {
         'job' => {
@@ -85,6 +114,10 @@ describe 'cd4pe_deployments::direct', if: Gem::Version.new(Puppet.version) >= Ge
         .with(query: { op: 'GetNodeGroupInfo', deploymentId: deployment_id, nodeGroupId: node_group_id }, headers: { 'authorization' => "Bearer token #{ENV['DEPLOYMENT_TOKEN']}" })
         .to_return(body: JSON.generate(node_group_response['result']))
         .times(1)
+
+      stub_request(:get, ajax_url)
+        .with(query: { op: 'GetDeploymentApprovalState', deploymentId: deployment_id},  headers: { 'authorization'=>"Bearer token #{ENV['DEPLOYMENT_TOKEN']}" })
+        .to_return(body: JSON.generate(approval_pending_response['result']))
 
       stub_request(:post, ajax_url)
         .with(


### PR DESCRIPTION
Previous to this commit, the cd4pe_deployments::wait_for_approval() function
would immediately attend to put the deployment approval into a pending
state. However, it's possible for the approval to already be approved
earlier in the deployment plan, before the wait_for_approval() function
is called.

This commit first checks the status of the deployment approval and
returns with the status if it's already approved or denied