### PR TITLE
(CDPE-3405) Lowercase rolling temp branch name

### DIFF
--- a/plans/rolling.pp
+++ b/plans/rolling.pp
@@ -78,7 +78,8 @@ plan cd4pe_deployments::rolling (
     }
   }
 
-  $branch = "ROLLING_DEPLOYMENT_${system::env('DEPLOYMENT_ID')}"
+  # Ensure our prefix is always lowercase to match to puppets suggested env regex pattern
+  $branch = "rolling_deployment_${system::env('DEPLOYMENT_ID')}"
   $tmp_git_branch_result = cd4pe_deployments::create_git_branch('CONTROL_REPO', $branch,  $sha, true)
   if ($tmp_git_branch_result[error]) {
     fail_plan("Could not create temporary git branch ${branch}: ${tmp_git_branch_result[error]}")


### PR DESCRIPTION
Previuos to this commit, our temp branch for rolling plan was created
with all caps `ROLLING_DEPLOYMENT`. However, puppet has a suggested
regex that all branch names should match (lowercase numbers and 0-9).
This commit changes the prefix we add to be lowercase. Since it is just
a suggestion, and depending on OS git branches are case sensitive, it is
best to not do a global downcase to not potentially break customer
workflows that depend on case sensitivity.