### PR TITLE
Revert "CDPE-3480: Pass docker_pull_creds to task"

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1088,14 +1088,6 @@ Data type: `Optional[Array[String[1]]]`
 
 Default value: `undef`
 
-##### `docker_pull_creds`
-
-Data type: `Optional[String[1]]`
-
-
-
-Default value: `undef`
-
 ##### `base_64_ca_cert`
 
 Data type: `Optional[String[1]]`

--- a/plans/cd4pe_job.pp
+++ b/plans/cd4pe_job.pp
@@ -6,7 +6,6 @@ plan cd4pe_deployments::cd4pe_job (
   Optional[Array[String[1]]]      $env_vars = undef,
   Optional[String[1]]             $docker_image = undef,
   Optional[Array[String[1]]]      $docker_run_args = undef,
-  Optional[String[1]]             $docker_pull_creds = undef,
   Optional[String[1]]             $base_64_ca_cert = undef,
 ) {
 
@@ -22,6 +21,5 @@ plan cd4pe_deployments::cd4pe_job (
     'env_vars' => $env_vars,
     'docker_image' => $docker_image,
     'docker_run_args' => $docker_run_args,
-    'docker_pull_creds' => $docker_pull_creds,
     'base_64_ca_cert' => $base_64_ca_cert,
 )}


### PR DESCRIPTION
Reverts puppetlabs/puppetlabs-cd4pe_deployments#58

Reverting this and leaving it on 4.0.0-release so it doesn't go out in any 3.x builds