### PR TITLE
CDPE-3563: Pass Docker registry CA cert

### DIFF
--- a/plans/cd4pe_job.pp
+++ b/plans/cd4pe_job.pp
@@ -7,14 +7,13 @@ plan cd4pe_deployments::cd4pe_job (
   Optional[String[1]]             $docker_image = undef,
   Optional[Array[String[1]]]      $docker_run_args = undef,
   Optional[String[1]]             $docker_pull_creds = undef,
+  Optional[String[1]]             $base_64_registry_ca_cert = undef,
   Optional[String[1]]             $base_64_ca_cert = undef,
 ) {
 
   $cd4pe_token = system::env('CD4PE_TOKEN')
 
-  return run_task(
-    'cd4pe_jobs::run_cd4pe_job',
-    $targets,
+  $_basic_args = {
     'job_instance_id' => $job_instance_id,
     'cd4pe_web_ui_endpoint' => $cd4pe_web_ui_endpoint,
     'cd4pe_token' => $cd4pe_token,
@@ -22,6 +21,24 @@ plan cd4pe_deployments::cd4pe_job (
     'env_vars' => $env_vars,
     'docker_image' => $docker_image,
     'docker_run_args' => $docker_run_args,
-    'docker_pull_creds' => $docker_pull_creds,
     'base_64_ca_cert' => $base_64_ca_cert,
-)}
+  }
+
+  $_args_with_creds = if $docker_pull_creds {
+    $_basic_args + {'docker_pull_creds' => $docker_pull_creds}
+  } else {
+    $_basic_args
+  }
+
+  $args_with_registry_cert = if $base_64_registry_ca_cert {
+    $_args_with_creds + {'base_64_registry_ca_cert' => $base_64_registry_ca_cert}
+  } else {
+    $_args_with_creds
+  }
+
+  return run_task(
+    'cd4pe_jobs::run_cd4pe_job',
+    $targets,
+    $args_with_registry_cert,
+  )
+}


### PR DESCRIPTION
Update the cd4pe_job plan to allow passing a separate Registry CA cert. Make that and passing Docker pull credentials optional for backward compatibility with puppetlabs-cd4pe_jobs 1.3.0.