### PR TITLE
(CDPE-3788) Use env var for node group env instead of api

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This module provides a set of tools, via CD4PE, for creating your own custom CD4
    - `BRANCH`: the name of the branch you are deploying _from_; your pipeline branch
    - `COMMIT`: HEAD commit SHA of the branch you are deploying from
    - `NODE_GROUP_ID`: alpha-numberic ID of the node group you are deploying _to_
+   - `NODE_GROUP_ENVIRONMENT`:the environment of the node group you are deploying _to_
    - `REPO_TARGET_BRANCH`: name of the source control branch that represents the target environment
    - `ENVIRONMENT_PREFIX`: if you are deploying to a prefixed environment, this is that prefix
    - `REPO_TYPE`: will either be "CONTROL_REPO" or "MODULE"

--- a/plans/eventual_consistency.pp
+++ b/plans/eventual_consistency.pp
@@ -11,12 +11,7 @@ plan cd4pe_deployments::eventual_consistency (
   $repo_type = system::env('REPO_TYPE')
   $repo_target_branch = system::env('REPO_TARGET_BRANCH')
   $source_commit = system::env('COMMIT')
-  $target_node_group_id = system::env('NODE_GROUP_ID')
-  $get_node_group_result = cd4pe_deployments::get_node_group($target_node_group_id)
-  if $get_node_group_result['error'] =~ NotUndef {
-    fail_plan($get_node_group_result['error']['message'], $get_node_group_result['error']['code'])
-  }
-  $target_environment = $get_node_group_result['result']['environment']
+  $target_environment = system::env('NODE_GROUP_ENVIRONMENT')
   # Wait for approval if the environment is protected
   cd4pe_deployments::wait_for_approval($target_environment) |String $url| { }
 


### PR DESCRIPTION
Previous to this commit, the eventual consistency plan would query a
CD4PE api endpoint that did recursive nodegroup rules lookups that
returned all nodes in the target environment. This was causing issues
for customers with large, complex rule sets. Eventual Consistency
doesn't care about the node list, only the environment that it is
deploying to.
This commit fixes the issue by instead using a new env var that is
available that has the node group environment to do a deploy to, so we do
not need to perform any extra lookups