### PR TITLE
(CDPE-4181) Respect uri path when hitting cd4pe backend

### DIFF
--- a/lib/puppet_x/puppetlabs/cd4pe_client.rb
+++ b/lib/puppet_x/puppetlabs/cd4pe_client.rb
@@ -19,8 +19,9 @@ module PuppetX::Puppetlabs
         deployment_id: deployment_id,
         deployment_owner: deployment_owner,
       }
-
-      @owner_ajax_path = "/#{deployment_owner}/ajax"
+      route_prefix = uri.path || ''
+      @owner_ajax_path = "#{route_prefix}/#{deployment_owner}/ajax"
+      @login_path = "#{route_prefix}/login"
     end
 
     def pin_nodes_to_env(nodes, node_group_id)
@@ -217,7 +218,7 @@ module PuppetX::Puppetlabs
           passwd: login_pwd,
         },
       }
-      make_request(:post, '/login', payload.to_json, 'anonymous')
+      make_request(:post, @login_path, payload.to_json, 'anonymous')
     end
 
     private


### PR DESCRIPTION
Prior to this change, if the web_ui_endpoint supplied by CD4PE contained
a path after the port, we ignored it and simply attempted to hit the
`server/port`. This historically worked just fine, as CD4PE never
specified a path after the port; however, in CD4PE 4.5.0, we introduced
a path prefix that all traffic to CD4PE has to respect.

With this change, we add logic to respect the URI path if one exists,
allowing us to use the cd4pe_deployments module with CD4PE 4.5.0+.