### PR TITLE
(maint) Remove secrets parameter when running task

### DIFF
--- a/plans/cd4pe_job.pp
+++ b/plans/cd4pe_job.pp
@@ -28,5 +28,4 @@ plan cd4pe_deployments::cd4pe_job (
     'docker_run_args' => $docker_run_args,
     'docker_pull_creds' => $docker_pull_creds,
     'base_64_ca_cert' => $base_64_ca_cert,
-    'secrets' => $secrets_hash,
 )}


### PR DESCRIPTION
We have not yet released the cd4pe_jobs module which causes cd4pe jobs
to fail when trying to pass in secrets (even if they're empty). Removed
the secrets arg when running the task to avoid error until we release
the module.