### PR TITLE
(CDPE-4537) Properly read CD4PE_MODULE_DEPLOY_READ_TIMEOUT env var

### DIFF
--- a/lib/puppet_x/puppetlabs/cd4pe_client.rb
+++ b/lib/puppet_x/puppetlabs/cd4pe_client.rb
@@ -267,12 +267,12 @@ module PuppetX::Puppetlabs
       # api as it is a long lived connection instead of polling for updates.
       # If env var is specified and valid, override.
       timeout = 600
-      env_var = ENV['CD4PE_MODULE_DEPLOY_READ_TIMEOUT']
-      unless env_var.nil?
-        if env_var.is_a?(Integer)
-          timeout = env_var
-        elsif env_var.is_a?(String) && !env_var.empty?
-          timeout = Integer(env_var)
+      env_var_val = ENV['CD4PE_MODULE_DEPLOY_READ_TIMEOUT']
+      unless env_var_val.nil?
+        if env_var_val.is_a?(Integer)
+          timeout = env_var_val
+        elsif env_var_val.is_a?(String) && !env_var_val.empty?
+          timeout = Integer(env_var_val)
         end
       end
       timeout


### PR DESCRIPTION
Prior to this change, if a user attempted to override the http read
timeout using the `CD4PE_MODULE_DEPLOY_READ_TIMEOUT` env var as an
String, the task would fail, as a string value of the override could not
be applied. When CD4PE 4x was released, it forced the user to define
this override in their kubernetes deployment, forcing the value to be
passed in as a string, meaning the override could never work.

With this change, we modify the code to handle either a string OR an
integer as an override, and fall back to a default of 600 seconds if
no override is detected.