### PR TITLE
(CDPE-4632) Enable cd4pe_client to use deployment_domain to hit new CD4PE API

### DIFF
--- a/lib/puppet_x/puppetlabs/cd4pe_client.rb
+++ b/lib/puppet_x/puppetlabs/cd4pe_client.rb
@@ -18,9 +18,11 @@ module PuppetX::Puppetlabs
         token: deployment_token,
         deployment_id: deployment_id,
         deployment_owner: deployment_owner,
+        deployment_domain: deployment_domain,
       }
       route_prefix = uri.path || ''
       @owner_ajax_path = "#{route_prefix}/#{deployment_owner}/ajax"
+      @api_v1_path = "#{route_prefix}/api/v1"
       @login_path = "#{route_prefix}/login"
     end
 
@@ -246,6 +248,13 @@ module PuppetX::Puppetlabs
       raise Puppet::Error, 'Could not get owner for deployment' unless owner
 
       owner
+    end
+
+    def deployment_domain
+      domain = ENV['DEPLOYMENT_DOMAIN']
+      raise Puppet::Error, 'Could not get domain for deployment' unless domain
+
+      domain
     end
 
     def deployment_id

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -56,6 +56,7 @@ RSpec.shared_context 'deployment' do
   let(:test_host) { 'http://puppet.test' }
   let(:deployment_owner) { 'ccaum' }
   let(:deployment_id) { '123' }
+  let(:deployment_domain) { 'd25' }
   let(:deployment_token) { '1234abcd' }
   let(:node_group_id) { 'aasdf-1234asdf-1234' }
   let(:environment_name) { 'development' }
@@ -63,6 +64,7 @@ RSpec.shared_context 'deployment' do
   let(:commit) { 'ef424ec352d4bc93317be901877e32f3c6a0289c' }
   let(:git_branch) { 'src_development' }
   let(:ajax_url) { "#{test_host}/#{deployment_owner}/ajax" }
+  let(:api_v1_path) { "#{test_host}/api/v1" }
   let(:response) do
     {
       'result' => {
@@ -87,6 +89,7 @@ RSpec.shared_context 'deployment' do
   before(:each) do
     ENV['DEPLOYMENT_OWNER'] = deployment_owner
     ENV['DEPLOYMENT_ID'] = deployment_id
+    ENV['DEPLOYMENT_DOMAIN'] = deployment_domain
     ENV['DEPLOYMENT_TOKEN'] = deployment_token
     ENV['WEB_UI_ENDPOINT'] = test_host
     ENV['REPO_TARGET_BRANCH'] = environment_name


### PR DESCRIPTION
With this change, we modify the cd4pe_client to store the
deployment_domain needed to hit the new CD4PE api.