### PR TITLE
(CDPE-5224) Allow ajax calls to work for all envs

### DIFF
--- a/lib/puppet_x/puppetlabs/cd4pe_client.rb
+++ b/lib/puppet_x/puppetlabs/cd4pe_client.rb
@@ -21,7 +21,7 @@ module PuppetX::Puppetlabs
         deployment_domain: deployment_domain,
       }
       route_prefix = uri.path || ''
-      @owner_ajax_path = "#{route_prefix}/#{deployment_owner}/ajax"
+      @owner_ajax_path = "/#{deployment_owner}/ajax"
       @api_v1_path = "#{route_prefix}/api/v1"
       @login_path = "#{route_prefix}/login"
     end


### PR DESCRIPTION
The cd4pe prefix can only be used in environemnts where the UI proxy is running (i.e. prod), but cannot be used when the proxy is not available (i.e. backend tests). Since the UI proxy already maps calls to `/:workspace/ajax` and `/cd4pe/:workspace/ajax` to the backend we can safely remove the prefix from all ajax calls and have it work for environments with and without a UI proxy.