### PR TITLE
(CDPE-4754) Migrate create_git_branch to V1 endpoint

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -154,9 +154,8 @@ The cd4pe_deployments::create_git_branch function.
 
 Returns: `Hash` contains the results of the function
 See [README.md]() for information on the CD4PEFunctionResult hash format
-* result [Hash]:
-  * success [Boolean] whether or not the operation was successful
-* error [Hash] contains error information if any
+* result [String] "success" on success
+* error [Hash] contains error information if any (message + HTTP status code)
 
 ##### Examples
 

--- a/lib/puppet/functions/cd4pe_deployments/create_git_branch.rb
+++ b/lib/puppet/functions/cd4pe_deployments/create_git_branch.rb
@@ -15,9 +15,8 @@ Puppet::Functions.create_function(:'cd4pe_deployments::create_git_branch') do
   #   create_git_branch("CONTROL_REPO", "feature_carlscoolfeature", "c090ea692e67405c5572af6b2a9dc5f11c9080c0")
   # @return [Hash] contains the results of the function
   #   See [README.md]() for information on the CD4PEFunctionResult hash format
-  #   * result [Hash]:
-  #     * success [Boolean] whether or not the operation was successful
-  #   * error [Hash] contains error information if any
+  #   * result [String] "success" on success
+  #   * error [Hash] contains error information if any (message + HTTP status code)
   #
   dispatch :create_git_branch do
     required_param 'Enum["CONTROL_REPO", "MODULE"]', :repo_type
@@ -31,14 +30,15 @@ Puppet::Functions.create_function(:'cd4pe_deployments::create_git_branch') do
 
     response = client.create_git_branch(repo_type, branch_name, commit_sha, cleanup)
     case response
-    when Net::HTTPSuccess
-      response_body = JSON.parse(response.body, symbolize_names: false)
-      return PuppetX::Puppetlabs::CD4PEFunctionResult.create_result(response_body)
+    when Net::HTTPNoContent
+      return PuppetX::Puppetlabs::CD4PEFunctionResult.create_result('success')
     when Net::HTTPClientError
-      response_body = JSON.parse(response.body, symbolize_names: false)
-      return PuppetX::Puppetlabs::CD4PEFunctionResult.create_error_result(response_body)
+      body = JSON.parse(response.body, symbolize_names: false)
+      return PuppetX::Puppetlabs::CD4PEFunctionResult.create_result(
+        nil, body['message'], response.code,
+      )
     when Net::HTTPServerError
-      raise Puppet::Error "Unknown HTTP Error with code: #{response.code} and body #{response.body}"
+      raise Puppet::Error, "Unknown HTTP Error with code: #{response.code} and body #{response.body}"
     end
   end
 end

--- a/lib/puppet_x/puppetlabs/cd4pe_client.rb
+++ b/lib/puppet_x/puppetlabs/cd4pe_client.rb
@@ -164,17 +164,15 @@ module PuppetX::Puppetlabs
     end
 
     def create_git_branch(repo_type, branch_name, commit_sha, cleanup)
+      path = "#{@api_v1_path}/deployments/#{@config[:deployment_id]}" \
+             ":create-git-branch?workspaceId=#{@config[:deployment_domain]}"
       payload = {
-        op: 'CreateGitBranch',
-        content: {
-          deploymentId: @config[:deployment_id],
-          repoType: repo_type,
-          branchName: branch_name,
-          commitSha: commit_sha,
-          cleanup: cleanup,
-        },
+        repoType: repo_type,
+        branchName: branch_name,
+        commitSha: commit_sha,
+        cleanup: cleanup,
       }
-      make_request(:post, @owner_ajax_path, payload.to_json)
+      make_request(:post, path, payload.to_json)
     end
 
     def get_git_branches(repo_type)

--- a/spec/functions/cd4pe/create_git_branch_spec.rb
+++ b/spec/functions/cd4pe/create_git_branch_spec.rb
@@ -3,8 +3,6 @@ require_relative '../../../lib/puppet/functions/cd4pe_deployments/create_git_bra
 require 'webmock/rspec'
 
 describe 'cd4pe_deployments::create_git_branch' do
-  let(:ajax_op) { 'CreateGitBranch' }
-
   context 'table steaks' do
     include_context 'deployment'
 
@@ -21,61 +19,72 @@ describe 'cd4pe_deployments::create_git_branch' do
     include_context 'deployment'
 
     let(:repo_type) { 'CONTROL_REPO' }
-    let(:git_branch) { 'development_b' }
+    let(:branch_name) { 'development_b' }
     let(:commit_sha) { 'c090ea692e67405c5572af6b2a9dc5f11c9080c0' }
-    let(:response) do
-      {
-        'result' => {
-          'success' => true,
-        },
-        'error' => nil,
+    let(:full_path) do
+      "#{api_v1_path}/deployments/#{deployment_id}:create-git-branch?workspaceId=#{deployment_domain}"
+    end
+
+    it 'returns success on 204' do
+      stub_request(:post, full_path)
+        .with(
+          body: {
+            repoType: repo_type,
+            branchName: branch_name,
+            commitSha: commit_sha,
+            cleanup: true,
+          },
+          headers: {
+            'authorization' => ENV['DEPLOYMENT_TOKEN'],
+          },
+        )
+        .to_return(status: 204, body: '')
+        .times(1)
+
+      is_expected
+        .to run
+        .with_params(repo_type, branch_name, commit_sha)
+        .and_return({'result' => 'success', 'error' => nil})
+    end
+
+    it 'returns error result on 4xx with a V1 error body' do
+      v1_error_body = {
+        'message' => 'Some error message',
+        'traceId' => 'abc',
+        'uriPath' => full_path,
       }
-    end
-
-    it 'succeeds with parameters' do
-      stub_request(:post, ajax_url)
+      stub_request(:post, full_path)
         .with(
           body: {
-            op: ajax_op,
-            content: {
-              repoType: repo_type,
-              deploymentId: deployment_id,
-              branchName: git_branch,
-              commitSha: commit_sha,
-              cleanup: true,
-            },
+            repoType: repo_type,
+            branchName: branch_name,
+            commitSha: commit_sha,
+            cleanup: true,
           },
           headers: {
             'authorization' => ENV['DEPLOYMENT_TOKEN'],
           },
         )
-        .to_return(body: JSON.generate(response['result']))
+        .to_return(status: 400, body: JSON.generate(v1_error_body))
         .times(1)
 
-      is_expected.to run.with_params(repo_type, git_branch, commit_sha).and_return(response)
+      is_expected
+        .to run
+        .with_params(repo_type, branch_name, commit_sha)
+        .and_return(
+          {'result' => nil, 'error' => {'message' => 'Some error message', 'code' => '400'}},
+        )
     end
 
-    it 'fails with non-200 response code' do
-      stub_request(:post, ajax_url)
-        .with(
-          body: {
-            op: ajax_op,
-            content: {
-              repoType: repo_type,
-              deploymentId: deployment_id,
-              branchName: git_branch,
-              commitSha: commit_sha,
-              cleanup: true,
-            },
-          },
-          headers: {
-            'authorization' => ENV['DEPLOYMENT_TOKEN'],
-          },
-        )
-        .to_return(body: JSON.generate(error_response), status: 404)
+    it 'raises on 5xx' do
+      stub_request(:post, full_path)
+        .to_return(status: 500, body: 'boom')
         .times(1)
 
-      is_expected.to run.with_params(repo_type, git_branch, commit_sha).and_return(error_response)
+      is_expected
+        .to run
+        .with_params(repo_type, branch_name, commit_sha)
+        .and_raise_error(Puppet::Error)
     end
   end
 end


### PR DESCRIPTION
## Summary

- Switches `cd4pe_deployments::create_git_branch` to call the new V1 endpoint `POST /v1/deployments/{id}:create-git-branch` instead of the legacy AJAX `op=CreateGitBranch`.
- Maps V1 error bodies (which use `BaseErrorV1` shape: `{message, traceId, uriPath}`) into the existing function-result error format consumed by Bolt plans.
- Fixes a pre-existing missing comma in the `Net::HTTPServerError` raise.
- Rewrites the spec to stub the V1 endpoint, asserts 204 → success, 4xx → mapped error, 5xx → \`Puppet::Error\`.

## Dependency

This depends on the matching PipelinesInfra change that adds the V1 endpoint. Ship them together — until the PipelinesInfra side lands, this client will get 404s.

PipelinesInfra PR: https://github.com/puppetlabs/PipelinesInfra/pull/5155

## Test plan

- [x] `bundle exec rspec spec/functions/cd4pe/create_git_branch_spec.rb` — 5 examples, 0 failures
- [ ] Integration: run a real CD4PE deployment exercising the function (rolling / eventual_consistency / feature_branch plan) against a PE backend built from the PipelinesInfra PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)