### PR TITLE
(CDPE-7451) Thread image_pull_policy through the cd4pe_job plan

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1125,6 +1125,7 @@ The following parameters are available in the `cd4pe_deployments::cd4pe_job` pla
 * [`docker_image`](#-cd4pe_deployments--cd4pe_job--docker_image)
 * [`docker_run_args`](#-cd4pe_deployments--cd4pe_job--docker_run_args)
 * [`docker_pull_creds`](#-cd4pe_deployments--cd4pe_job--docker_pull_creds)
+* [`image_pull_policy`](#-cd4pe_deployments--cd4pe_job--image_pull_policy)
 * [`base_64_ca_cert`](#-cd4pe_deployments--cd4pe_job--base_64_ca_cert)
 * [`secret_env_vars`](#-cd4pe_deployments--cd4pe_job--secret_env_vars)
 
@@ -1179,6 +1180,14 @@ Default value: `undef`
 ##### <a name="-cd4pe_deployments--cd4pe_job--docker_pull_creds"></a>`docker_pull_creds`
 
 Data type: `Optional[String[1]]`
+
+
+
+Default value: `undef`
+
+##### <a name="-cd4pe_deployments--cd4pe_job--image_pull_policy"></a>`image_pull_policy`
+
+Data type: `Optional[Enum['Always', 'IfNotPresent', 'Never']]`
 
 
 

--- a/plans/cd4pe_job.pp
+++ b/plans/cd4pe_job.pp
@@ -1,14 +1,15 @@
 plan cd4pe_deployments::cd4pe_job (
-  TargetSpec                      $targets,
-  String[1]                       $job_instance_id,
-  String[1]                       $cd4pe_web_ui_endpoint,
-  String[1]                       $cd4pe_job_owner,
-  Optional[Array[String[1]]]      $env_vars = undef,
-  Optional[String[1]]             $docker_image = undef,
-  Optional[Array[String[1]]]      $docker_run_args = undef,
-  Optional[String[1]]             $docker_pull_creds = undef,
-  Optional[String[1]]             $base_64_ca_cert = undef,
-  Optional[Array[String[1]]]      $secret_env_vars = [],
+  TargetSpec                                        $targets,
+  String[1]                                         $job_instance_id,
+  String[1]                                         $cd4pe_web_ui_endpoint,
+  String[1]                                         $cd4pe_job_owner,
+  Optional[Array[String[1]]]                        $env_vars = undef,
+  Optional[String[1]]                               $docker_image = undef,
+  Optional[Array[String[1]]]                        $docker_run_args = undef,
+  Optional[String[1]]                               $docker_pull_creds = undef,
+  Optional[Enum['Always', 'IfNotPresent', 'Never']] $image_pull_policy = undef,
+  Optional[String[1]]                               $base_64_ca_cert = undef,
+  Optional[Array[String[1]]]                        $secret_env_vars = [],
 ) {
   $cd4pe_token = system::env('CD4PE_TOKEN')
 
@@ -24,13 +25,18 @@ plan cd4pe_deployments::cd4pe_job (
     'base_64_ca_cert' => $base_64_ca_cert,
   }
 
+  $params_with_policy = $image_pull_policy ? {
+    undef   => $base_task_params,
+    default => $base_task_params + { 'image_pull_policy' => $image_pull_policy },
+  }
+
   $task_params = if $secret_env_vars.empty {
-    $base_task_params
+    $params_with_policy
   } else {
     $secrets_hash = $secret_env_vars.reduce({}) |$memo, $value| {
       $memo + { $value => system::env($value) }
     }
-    $base_task_params + { 'secrets' => $secrets_hash }
+    $params_with_policy + { 'secrets' => $secrets_hash }
   }
 
   $result_or_error = catch_errors() || {


### PR DESCRIPTION
## What this PR does
Threads the `image_pull_policy` value through the `cd4pe_job` plan, forwarding it to the `run_cd4pe_job` task **only when set**. Because the parameter is passed conditionally, a `cd4pe_jobs` task release that predates the parameter still runs unaffected jobs (Bolt validates parameter names) — this mirrors the plan's existing conditional handling of optional params.

## Spec
Design doc lives in the monorepo diff: `dev/specs/2026-07-15-cdpe-7451-image-pull-policy-design.md` (see the PipelinesInfra PR below).

## Cross-repo dependency
Part of the CDPE-7451 image-pull-policy work spanning three repos:

- **puppetlabs-cd4pe_jobs** — the task that accepts/enforces the policy: puppetlabs/puppetlabs-cd4pe_jobs#62 **(release prerequisite)**.
- **puppetlabs-cd4pe_deployments (this PR)** — threads the param through the `cd4pe_job` plan.
- **PipelinesInfra (monorepo)** — backend + SPA that emit the policy. (link added below)

This plan change is **downstream of the cd4pe_jobs task** (#62): it only forwards a parameter the task must understand. It is safe to merge ahead of the task release because it passes `image_pull_policy` only when set, so default (`Always`) jobs are never sent the param. A non-default policy end-to-end still requires the cd4pe_jobs release (#62) first.
